### PR TITLE
fix: correct cargo test command to use proper feature flag

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -35,6 +35,8 @@ pub fn test() -> Result<(), Error> {
     match (has_cargo, has_package_json) {
         (true, _) => {
             let output = Command::new("cargo")
+                .arg("test")
+                .arg("--features")
                 .arg("test-sbf")
                 .arg("--")
                 .arg("--nocapture")


### PR DESCRIPTION
##  Bug Fix

**Problem:** The test command was using `cargo test-sbf` which is a non-existent command, causing all tests to fail.

<img width="658" height="327" alt="Screenshot 2025-08-07 at 9 39 33 AM" src="https://github.com/user-attachments/assets/50f1173f-ee7b-4c08-b8d4-651d2ab6fbb3" />

**Root Cause:** The command should use `cargo test --features test-sbf` to properly enable the test-sbf feature defined in the generated Cargo.toml.

## �� Changes

<img width="657" height="206" alt="Screenshot 2025-08-07 at 9 41 41 AM" src="https://github.com/user-attachments/assets/bd5ce914-bcb5-4d6c-8473-b550dd8c8363" />

- Replace `cargo test-sbf` with `cargo test --features test-sbf`
- Maintains compatibility with existing test-sbf feature in Cargo.toml
- No breaking changes or API modifications

## ✅ Testing

**Before Fix:**
```bash
error: no such command: `test-sbf`
help: view all installed commands with `cargo --list`
❌ All tests failed (0 passed, 2 failed)
```

**After Fix:**
```bash
✅ All tests pass (2 passed, 0 failed)
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
```


## 🔍 Technical Details

The fix aligns with the `test-sbf` feature defined in the generated Cargo.toml:
```toml
[features]
test-sbf = []
```
