### PR TITLE
Added parsing error on jumps with undefined labels

### DIFF
--- a/crates/assembler/src/parser.rs
+++ b/crates/assembler/src/parser.rs
@@ -760,6 +760,8 @@ impl Parser {
                                 // Replace label with immediate value
                                 let last_idx = operands.len() - 1;
                                 operands[last_idx] = Token::ImmediateValue(ImmediateValue::Int(rel_offset), span.clone());
+                            } else {
+                                errors.push(CompileError::UndefinedLabel { label: label.clone(), span: span.clone(), custom_label: None });
                             }
                         }
                     }


### PR DESCRIPTION
Currently, jumps with undefined labels are simply omitted from the generated bytecode without any warning or error. This PR adds an error to this case.