### PR TITLE
feat: add unary + -, binary * /, parentheses support and refactor const folding

### DIFF
--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -61,7 +61,11 @@ define_compile_errors! {
         label = "Unexpected token",
         fields = { token: String, span: Range<usize> }
     },
-
+    UnmatchedParen {
+        error = "Unmatched parenthesis",
+        label = "Unmatched parenthesis",
+        fields = { span: Range<usize> }
+    },
     // Semantic errors
     UndefinedLabel {
         error = "Undefined label '{label}'",


### PR DESCRIPTION
- Added support for unary + and - operators in expression parsing
- Implemented binary * and / operators with proper precedence handling
- Added parentheses grouping to override operator precedence
- Refactored constant folding logic to evaluate unary, binary, and nested expressions