### PR TITLE
feat/fix: add internal call support and fix neg32/neg64 instructions (Issue #17 #19)

### DIFF
--- a/crates/assembler/src/messages.rs
+++ b/crates/assembler/src/messages.rs
@@ -9,6 +9,7 @@ pub const EXPECTS_LABEL_DIR_STR: &str = "expects <label>, <directive>, <string l
 pub const EXPECTS_IDEN: &str = "expects <identifier>";
 pub const EXPECTS_IDEN_COM_IMM: &str = "expects <identifier>, <immediate value>";
 pub const EXPECTS_MORE_OPERAND: &str = "expects more operand";
+pub const EXPECTS_REG: &str = "expects <register>";
 pub const EXPECTS_REG_COM_IMM: &str = "expects <register>, <immediate value>";
 pub const EXPECTS_REG_COM_REG: &str = "expects <register>, <register>";
 pub const EXPECTS_REG_COM_IMM_OR_IDEN: &str = "expects <register>, <immediate value>/<identifier>";


### PR DESCRIPTION
internal calls are handled in the same way as jump instructions - resolve labels after first pass and replace the operand with relative offset. Except that we don't error out when call labels are not resolved, since they could be external calls and are handled by text relocation instead