### PR TITLE
assembler: detect and error on duplicate labels instead of silently overwriting

### DIFF
--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -72,6 +72,11 @@ define_compile_errors! {
         label = "Undefined label",
         fields = { label: String, span: Range<usize> }
     },
+    DuplicateLabel {
+        error = "Duplicate label '{label}'",
+        label = "Label redefined",
+        fields = { label: String, span: Range<usize> }
+    },
 }
 
 

--- a/crates/assembler/src/parser.rs
+++ b/crates/assembler/src/parser.rs
@@ -889,7 +889,11 @@ impl Parser {
                     if rodata_phase {
                         match ROData::parse(tokens) {
                             Ok((rodata, rest)) => {
-                            self.m_label_offsets.insert(name.clone(), self.m_accum_offset + self.m_rodata_size);
+                            if self.m_label_offsets.contains_key(name) {
+                                errors.push(CompileError::DuplicateLabel { label: name.clone(), span: span.clone(), custom_label: None });
+                            } else {
+                                self.m_label_offsets.insert(name.clone(), self.m_accum_offset + self.m_rodata_size);
+                            }
                             self.m_rodata_size += rodata.get_size();
                             rodata_nodes.push(ASTNode::ROData { rodata, offset: self.m_accum_offset });
                             tokens = rest;
@@ -900,7 +904,11 @@ impl Parser {
                             }
                         }
                     } else {
-                        self.m_label_offsets.insert(name.clone(), self.m_accum_offset);
+                        if self.m_label_offsets.contains_key(name) {
+                            errors.push(CompileError::DuplicateLabel { label: name.clone(), span: span.clone(), custom_label: None });
+                        } else {
+                            self.m_label_offsets.insert(name.clone(), self.m_accum_offset);
+                        }
                         nodes.push(ASTNode::Label { label: Label { name: name.clone(), span: span.clone() } });
                         tokens = &tokens[1..];
                     }


### PR DESCRIPTION
Problem: Defining the same label more than once silently overwrote its offset in `m_label_offsets`, causing hard‑to‑trace control‑flow bugs.

- Change: 
  - Added a new `DuplicateLabel` compiler error.
  - In `parser.rs`, before inserting a label into `m_label_offsets` (both code and rodata), we now check for an existing entry and emit `DuplicateLabel` if found.
- Behavior:
  - Before: `label:` redefined later would overwrite the first definition without any diagnostics.
  - After: A clear error is emitted: “Duplicate label '<name>'” with a precise span.
- Scope:
  - Only affects label insertion; no changes to encoding, relocation, or extern call behavior.
- Compatibility:
  - Backward compatible for valid programs; previously ambiguous/buggy programs now fail fast with a clear diagnostic.
- Testing:
  - Verified with a local unit test (not included in the repo) that assembling code with two `entrypoint:` labels reports `Duplicate label 'entrypoint'`.
- Example
  - Input:
    ```
    .globl entrypoint
    entrypoint:
      exit
    entrypoint:
      exit
    ```
  - Output: DuplicateLabel error at the second `entrypoint:` definition.