### PR TITLE
Assembler: error on duplicate labels with original definition location

### DIFF
--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -90,7 +90,7 @@ pub trait AsDiagnostic {
 impl AsDiagnostic for CompileError {
     fn to_diagnostic(&self) -> Diagnostic<()> {
         match self {
-            // will show both the redefinition and original definition
+            // Show both the redefinition and the original definition
             CompileError::DuplicateLabel { span, original_span, .. } => {
                 Diagnostic::error()
                     .with_message(self.to_string())

--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -90,6 +90,7 @@ pub trait AsDiagnostic {
 impl AsDiagnostic for CompileError {
     fn to_diagnostic(&self) -> Diagnostic<()> {
         match self {
+            // will show both the redefinition and original definition
             CompileError::DuplicateLabel { span, original_span, .. } => {
                 Diagnostic::error()
                     .with_message(self.to_string())


### PR DESCRIPTION
#21  follow up @deanmlittle 

### PR description

  - Detect and error on duplicate label definitions instead of silently overwriting.
  - Show both the redefinition site and the original definition’s location in diagnostics.
  - Include the original line number in the primary label text.

- Behavior
  - Before: redefining a label overwrote the first definition without diagnostics.
  - After: clear error with precise spans and the original line number.

