### PR TITLE
feat: add .byte .short .int .long .quad support

### DIFF
--- a/crates/assembler/src/astnode.rs
+++ b/crates/assembler/src/astnode.rs
@@ -438,14 +438,9 @@ impl ASTNode {
                     &args[0],
                     &args[1],
                 ) {
-                    (Token::Directive(directive, _), Token::StringLiteral(str_literal, _)) => {
-                        if directive == "ascii" {
-                            // Convert string to bytes and add null terminator
-                            let str_bytes = str_literal.as_bytes().to_vec();
-                            bytes.extend(str_bytes);
-                        } else {
-                            panic!("Invalid ROData declaration");
-                        }
+                    (Token::Directive(_, _), Token::StringLiteral(str_literal, _)) => {
+                        let str_bytes = str_literal.as_bytes().to_vec();
+                        bytes.extend(str_bytes);
                     } 
                     (Token::Directive(directive, _), Token::ImmediateValue(imm, _)) => {
                         if directive == "byte" {

--- a/crates/assembler/src/astnode.rs
+++ b/crates/assembler/src/astnode.rs
@@ -127,9 +127,9 @@ impl ROData {
                     "quad" => {
                         size = 8;
                     }
-                    "octa" => {
-                        size = 16;
-                    }
+                    // "octa" => {
+                    //     size = 16;
+                    // }
                     _ => panic!("Invalid ROData declaration"),
                 }
             }
@@ -185,29 +185,9 @@ impl ROData {
                             }
                         }
                     }
-                    "quad" => {
-                        if let Token::ImmediateValue(value, _) = &self.args[1] {
-                            match value {
-                                ImmediateValue::Int(val) => if *val < i64::MIN as i64 || *val > i64::MAX as i64 {
-                                    return Err(CompileError::OutOfRangeLiteral { span: immediate_value_span.clone(), custom_label: None });
-                                },
-                                ImmediateValue::Addr(val) => if *val < i64::MIN as i64 || *val > i64::MAX as i64 {
-                                    return Err(CompileError::OutOfRangeLiteral { span: immediate_value_span.clone(), custom_label: None });
-                                },
-                            }
-                        }
-                    }
-                    "octa" => {
-                        if let Token::ImmediateValue(value, _) = &self.args[1] {
-                            match value {
-                                ImmediateValue::Int(val) => if *val < i128::MIN as i64 || *val > i128::MAX as i64 {
-                                    return Err(CompileError::OutOfRangeLiteral { span: directive_span.clone(), custom_label: None });
-                                },
-                                ImmediateValue::Addr(val) => if *val < i128::MIN as i64 || *val > i128::MAX as i64 {
-                                    return Err(CompileError::OutOfRangeLiteral { span: directive_span.clone(), custom_label: None });
-                                },
-                            }
-                        }
+                    "quad" | "octa"=> {
+                        // this should be errored out at parsing time
+                        return Ok(());
                     }
                     _ => {
                         return Err(CompileError::InvalidRODataDirective { span: directive_span.clone(), custom_label: None });

--- a/crates/assembler/src/astnode.rs
+++ b/crates/assembler/src/astnode.rs
@@ -185,7 +185,7 @@ impl ROData {
                             }
                         }
                     }
-                    "quad" | "octa"=> {
+                    "quad" => {
                         // this should be errored out at parsing time
                         return Ok(());
                     }

--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -66,6 +66,16 @@ define_compile_errors! {
         label = "Unmatched parenthesis",
         fields = { span: Range<usize> }
     },
+    OutOfRangeLiteral {
+        error = "Out of range literal'",
+        label = "Out of range literal",
+        fields = { span: Range<usize> }
+    },
+    InvalidRODataDirective {
+        error = "Invalid rodata directive",
+        label = "Invalid rodata directive",
+        fields = { span: Range<usize> }
+    },
     // Semantic errors
     UndefinedLabel {
         error = "Undefined label '{label}'",

--- a/crates/assembler/src/parser.rs
+++ b/crates/assembler/src/parser.rs
@@ -173,6 +173,22 @@ impl Parse for ROData {
                     &tokens[3..]
                 ))
             }
+            (
+                Token::Label(name, span),
+                Token::Directive(_, _),
+                Token::ImmediateValue(_, _)
+            ) => {
+                args.push(tokens[1].clone());
+                args.push(tokens[2].clone());
+                Ok((
+                    ROData {
+                        name: name.clone(),
+                        args,
+                        span: span.clone()
+                    },
+                    &tokens[3..]
+                ))
+            }
             _ => Err(CompileError::InvalidRodataDecl { span: span.clone(), custom_label: Some(EXPECTS_LABEL_DIR_STR.to_string()) }),
         }
     }

--- a/crates/assembler/src/parser.rs
+++ b/crates/assembler/src/parser.rs
@@ -905,10 +905,14 @@ impl Parser {
                     if rodata_phase {
                         match ROData::parse(tokens) {
                             Ok((rodata, rest)) => {
-                            self.m_label_offsets.insert(name.clone(), self.m_accum_offset + self.m_rodata_size);
-                            self.m_rodata_size += rodata.get_size();
-                            rodata_nodes.push(ASTNode::ROData { rodata, offset: self.m_accum_offset });
-                            tokens = rest;
+                                self.m_label_offsets.insert(name.clone(), self.m_accum_offset + self.m_rodata_size);
+                                if let Err(e) = rodata.verify() {
+                                    errors.push(e);
+                                } else {
+                                    self.m_rodata_size += rodata.get_size();
+                                }
+                                rodata_nodes.push(ASTNode::ROData { rodata, offset: self.m_accum_offset });
+                                tokens = rest;
                             }
                             Err(e) => {
                                 errors.push(e);

--- a/crates/assembler/src/program.rs
+++ b/crates/assembler/src/program.rs
@@ -70,8 +70,6 @@ impl Program {
         current_offset += padding;
 
         if !is_static {
-
-
             let mut symbol_names = Vec::new();
             let mut dyn_syms = Vec::new();
             let mut dyn_str_offset = 1;


### PR DESCRIPTION
.octa needs another value type for i128, we can update it in the future
.quad overflow is detected during token creation
.byte .short .int .long overflow are detected during the rodata node verify

There might be more and will find an exhaustive list of every number directive in llvm