### PR TITLE
feat: add .include directive for multi-file assembly

### DIFF
--- a/crates/assembler/Cargo.toml
+++ b/crates/assembler/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 
 [dev-dependencies]
 blake3 = "1"
+tempfile = "3"
 toml = "0.8"
 serde = { version = "1.0.219", features = ["derive"] }
 object = { workspace = true }

--- a/crates/assembler/src/ast.rs
+++ b/crates/assembler/src/ast.rs
@@ -270,6 +270,10 @@ impl AST {
                 prog_is_static: program_is_static,
                 arch,
                 debug_sections: Vec::default(),
+                sources: std::collections::HashMap::new(),
+                code_file_info: Vec::new(),
+                rodata_file_info: Vec::new(),
+                label_file_info: std::collections::HashMap::new(),
             })
         }
     }

--- a/crates/assembler/src/ast.rs
+++ b/crates/assembler/src/ast.rs
@@ -113,7 +113,7 @@ impl AST {
         // iterate through text labels and rodata labels and find the pair
         // of each label and offset
         for (idx, node) in self.nodes.iter().enumerate() {
-            if let ASTNode::Label { label, offset } = node {
+            if let ASTNode::Label { label, offset, .. } = node {
                 label_offset_map.insert(label.name.clone(), *offset);
                 // Also track numeric labels separately for forward/backward resolution
                 numeric_labels.push((label.name.clone(), *offset, idx));
@@ -121,7 +121,7 @@ impl AST {
         }
 
         for node in &self.rodata_nodes {
-            if let ASTNode::ROData { rodata, offset } = node {
+            if let ASTNode::ROData { rodata, offset, .. } = node {
                 label_offset_map.insert(rodata.name.clone(), *offset + self.text_size);
             }
         }
@@ -144,6 +144,7 @@ impl AST {
             if let ASTNode::Instruction {
                 instruction: inst,
                 offset,
+                ..
             } = node
                 && inst.is_syscall()
                 && let Some(Either::Left(syscall_name)) = &inst.imm
@@ -197,6 +198,7 @@ impl AST {
                             label: label.clone(),
                             span: inst.span.clone(),
                             custom_label: None,
+                            file: None,
                         });
                     }
                 } else if inst.opcode == Opcode::Call
@@ -236,6 +238,7 @@ impl AST {
                             label: name.clone(),
                             span: inst.span.clone(),
                             custom_label: None,
+                            file: None,
                         });
                     }
                 }
@@ -271,9 +274,6 @@ impl AST {
                 arch,
                 debug_sections: Vec::default(),
                 sources: std::collections::HashMap::new(),
-                code_file_info: Vec::new(),
-                rodata_file_info: Vec::new(),
-                label_file_info: std::collections::HashMap::new(),
             })
         }
     }
@@ -315,6 +315,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: inst,
             offset: 0,
+            file: None,
         });
 
         let found = ast.get_instruction_at_offset(0);
@@ -339,6 +340,7 @@ mod tests {
         ast.rodata_nodes.push(ASTNode::ROData {
             rodata: rodata.clone(),
             offset: 0,
+            file: None,
         });
 
         let found = ast.get_rodata_at_offset(0);
@@ -382,6 +384,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: inst,
             offset: 0,
+            file: None,
         });
         ast.set_text_size(8);
         ast.set_rodata_size(0);
@@ -408,6 +411,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: inst,
             offset: 0,
+            file: None,
         });
         ast.set_text_size(8);
 
@@ -430,6 +434,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: syscall_inst,
             offset: 0,
+            file: None,
         });
 
         let exit_inst = Instruction {
@@ -443,6 +448,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: exit_inst,
             offset: 8,
+            file: None,
         });
 
         ast.set_text_size(16);
@@ -471,6 +477,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: syscall_inst,
             offset: 0,
+            file: None,
         });
 
         let exit_inst = Instruction {
@@ -484,6 +491,7 @@ mod tests {
         ast.nodes.push(ASTNode::Instruction {
             instruction: exit_inst,
             offset: 8,
+            file: None,
         });
 
         ast.set_text_size(16);

--- a/crates/assembler/src/astnode.rs
+++ b/crates/assembler/src/astnode.rs
@@ -25,15 +25,21 @@ pub enum ASTNode {
     Label {
         label: Label,
         offset: u64,
+        /// Source file this label was defined in (`None` in single-file mode).
+        file: Option<String>,
     },
     // present in both AST and bytecode
     ROData {
         rodata: ROData,
         offset: u64,
+        /// Source file this rodata was defined in (`None` in single-file mode).
+        file: Option<String>,
     },
     Instruction {
         instruction: Instruction,
         offset: u64,
+        /// Source file this instruction was defined in (`None` in single-file mode).
+        file: Option<String>,
     },
 }
 
@@ -113,6 +119,7 @@ impl ROData {
             return Err(CompileError::OutOfRangeLiteral {
                 span,
                 custom_label: None,
+                file: None,
             });
         }
         Ok(())
@@ -152,6 +159,7 @@ impl ROData {
                     return Err(CompileError::InvalidRODataDirective {
                         span: directive_span.clone(),
                         custom_label: None,
+                        file: None,
                     });
                 }
             }
@@ -203,6 +211,7 @@ impl ROData {
                     return Err(CompileError::InvalidRODataDirective {
                         span: directive_span.clone(),
                         custom_label: None,
+                        file: None,
                     });
                 }
             },
@@ -210,6 +219,7 @@ impl ROData {
                 return Err(CompileError::InvalidRodataDecl {
                     span: self.span.clone(),
                     custom_label: None,
+                    file: None,
                 });
             }
         }
@@ -487,6 +497,7 @@ mod tests {
         let node = ASTNode::Instruction {
             instruction: inst,
             offset: 0,
+            file: None,
         };
 
         let bytecode = node.bytecode();
@@ -504,7 +515,11 @@ mod tests {
             ],
             span: 0..10,
         };
-        let node = ASTNode::ROData { rodata, offset: 0 };
+        let node = ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        };
 
         let bytecode = node.bytecode();
         assert!(bytecode.is_some());
@@ -521,7 +536,11 @@ mod tests {
             ],
             span: 0..13,
         };
-        let node = ASTNode::ROData { rodata, offset: 0 };
+        let node = ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        };
 
         let bytecode = node.bytecode();
         assert!(bytecode.is_some());
@@ -538,7 +557,11 @@ mod tests {
             ],
             span: 0..12,
         };
-        let node = ASTNode::ROData { rodata, offset: 0 };
+        let node = ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        };
 
         let bytecode = node.bytecode();
         assert!(bytecode.is_some());
@@ -557,7 +580,11 @@ mod tests {
             ],
             span: 0..14,
         };
-        let node = ASTNode::ROData { rodata, offset: 0 };
+        let node = ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        };
 
         let bytecode = node.bytecode();
         assert!(bytecode.is_some());
@@ -575,7 +602,11 @@ mod tests {
             ],
             span: 0..21,
         };
-        let node = ASTNode::ROData { rodata, offset: 0 };
+        let node = ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        };
 
         let bytecode = node.bytecode();
         assert!(bytecode.is_some());
@@ -591,6 +622,7 @@ mod tests {
                 span: 0..4,
             },
             offset: 0,
+            file: None,
         };
         assert!(node.bytecode().is_none());
     }

--- a/crates/assembler/src/debug.rs
+++ b/crates/assembler/src/debug.rs
@@ -16,6 +16,14 @@ pub struct DebugData {
     pub directory: String,
     pub lines: Vec<(u64, u32)>,
     pub labels: Vec<(String, u64, u32)>,
+    /// Multi-file line entries: `(offset, filename, directory, line)`.
+    /// When non-empty, used instead of `lines` for DWARF emission so the
+    /// step debugger can map each instruction back to the `.s` file that
+    /// contained it (including included files).
+    pub lines_multi: Vec<(u64, String, String, u32)>,
+    /// Multi-file label entries: `(name, offset, filename, directory, line)`.
+    /// When non-empty, used instead of `labels` for DWARF emission.
+    pub labels_multi: Vec<(String, u64, String, String, u32)>,
     pub code_start: u64,
     pub code_end: u64,
 }
@@ -89,7 +97,12 @@ pub fn generate_debug_sections(
     sections
 }
 
-// Generate DWARF sections using gimli
+// Generate DWARF sections using gimli.
+//
+// If `data.lines_multi` / `data.labels_multi` are non-empty, the line
+// program is built with one DWARF file entry per distinct source file,
+// so the step debugger can resolve each instruction to the correct
+// included `.s` file. Otherwise the single-file path is used.
 fn generate_dwarf_sections(
     data: &DebugData,
     text_offset: u64,
@@ -109,33 +122,70 @@ fn generate_dwarf_sections(
 
     let mut dwarf = DwarfUnit::new(encoding);
 
-    // Add strings.
-    let dir_string_id = dwarf.line_strings.add(data.directory.clone().into_bytes());
-    let file_string_id = dwarf.line_strings.add(data.filename.clone().into_bytes());
+    let use_multi = !data.lines_multi.is_empty();
 
-    // Create line program.
+    // Build the line program. In multi-file mode we register every
+    // `(directory, filename)` referenced by `lines_multi` and emit rows
+    // that point at the right file id.
+    let main_dir_string_id = dwarf.line_strings.add(data.directory.clone().into_bytes());
+    let main_file_string_id = dwarf.line_strings.add(data.filename.clone().into_bytes());
     let mut line_program = LineProgram::new(
         encoding,
         line_encoding,
-        LineString::LineStringRef(dir_string_id),
+        LineString::LineStringRef(main_dir_string_id),
         None,
-        LineString::LineStringRef(file_string_id),
+        LineString::LineStringRef(main_file_string_id),
         None,
     );
 
-    let dir_id = line_program.default_directory();
-    let file_id = line_program.add_file(LineString::LineStringRef(file_string_id), dir_id, None);
+    if use_multi {
+        use std::collections::HashMap;
 
-    // Add line entries.
-    line_program.begin_sequence(Some(Address::Constant(code_start)));
-    for (address, line) in &data.lines {
-        let adjusted_addr = address + text_offset;
-        line_program.row().file = file_id;
-        line_program.row().address_offset = adjusted_addr - code_start;
-        line_program.row().line = *line as u64;
-        line_program.generate_row();
+        let mut dir_ids: HashMap<String, gimli::write::DirectoryId> = HashMap::new();
+        let mut file_ids: HashMap<(String, String), gimli::write::FileId> = HashMap::new();
+
+        // Walk the lines once to register all (dir, file) entries in a
+        // stable order.
+        for (_, filename, directory, _) in &data.lines_multi {
+            let dir_id = *dir_ids.entry(directory.clone()).or_insert_with(|| {
+                let id = dwarf.line_strings.add(directory.clone().into_bytes());
+                line_program.add_directory(LineString::LineStringRef(id))
+            });
+            file_ids
+                .entry((filename.clone(), directory.clone()))
+                .or_insert_with(|| {
+                    let id = dwarf.line_strings.add(filename.clone().into_bytes());
+                    line_program.add_file(LineString::LineStringRef(id), dir_id, None)
+                });
+        }
+
+        line_program.begin_sequence(Some(Address::Constant(code_start)));
+        for (address, filename, directory, line) in &data.lines_multi {
+            let adjusted_addr = address + text_offset;
+            if let Some(file_id) = file_ids.get(&(filename.clone(), directory.clone())) {
+                line_program.row().file = *file_id;
+            }
+            line_program.row().address_offset = adjusted_addr - code_start;
+            line_program.row().line = *line as u64;
+            line_program.generate_row();
+        }
+        line_program.end_sequence(code_end);
+    } else {
+        let dir_id = line_program.default_directory();
+        let file_id =
+            line_program.add_file(LineString::LineStringRef(main_file_string_id), dir_id, None);
+
+        // Add line entries.
+        line_program.begin_sequence(Some(Address::Constant(code_start)));
+        for (address, line) in &data.lines {
+            let adjusted_addr = address + text_offset;
+            line_program.row().file = file_id;
+            line_program.row().address_offset = adjusted_addr - code_start;
+            line_program.row().line = *line as u64;
+            line_program.generate_row();
+        }
+        line_program.end_sequence(code_end);
     }
-    line_program.end_sequence(code_end);
 
     dwarf.unit.line_program = line_program;
 
@@ -170,21 +220,44 @@ fn generate_dwarf_sections(
     root.set(DW_AT_stmt_list, AttributeValue::LineProgramRef);
 
     // Set labels.
-    for (name, address, line) in &data.labels {
-        let adjusted_addr = address + text_offset;
-        let label_id = dwarf.unit.add(root_id, DW_TAG_label);
-        let label_die = dwarf.unit.get_mut(label_id);
+    if use_multi {
+        for (name, address, _filename, _directory, line) in &data.labels_multi {
+            let adjusted_addr = address + text_offset;
+            let label_id = dwarf.unit.add(root_id, DW_TAG_label);
+            let label_die = dwarf.unit.get_mut(label_id);
 
-        label_die.set(
-            DW_AT_name,
-            AttributeValue::String(name.clone().into_bytes()),
-        );
-        label_die.set(DW_AT_decl_file, AttributeValue::Data4(0));
-        label_die.set(DW_AT_decl_line, AttributeValue::Data4(*line));
-        label_die.set(
-            DW_AT_low_pc,
-            AttributeValue::Address(Address::Constant(adjusted_addr)),
-        );
+            label_die.set(
+                DW_AT_name,
+                AttributeValue::String(name.clone().into_bytes()),
+            );
+            // DW_AT_decl_file: we keep 0 for now (main file). Proper
+            // per-label file attribution would need mapping names back to
+            // file ids; step-debugger line mapping is the primary concern
+            // and uses the line program above.
+            label_die.set(DW_AT_decl_file, AttributeValue::Data4(0));
+            label_die.set(DW_AT_decl_line, AttributeValue::Data4(*line));
+            label_die.set(
+                DW_AT_low_pc,
+                AttributeValue::Address(Address::Constant(adjusted_addr)),
+            );
+        }
+    } else {
+        for (name, address, line) in &data.labels {
+            let adjusted_addr = address + text_offset;
+            let label_id = dwarf.unit.add(root_id, DW_TAG_label);
+            let label_die = dwarf.unit.get_mut(label_id);
+
+            label_die.set(
+                DW_AT_name,
+                AttributeValue::String(name.clone().into_bytes()),
+            );
+            label_die.set(DW_AT_decl_file, AttributeValue::Data4(0));
+            label_die.set(DW_AT_decl_line, AttributeValue::Data4(*line));
+            label_die.set(
+                DW_AT_low_pc,
+                AttributeValue::Address(Address::Constant(adjusted_addr)),
+            );
+        }
     }
 
     // Write sections.
@@ -247,6 +320,8 @@ mod tests {
             directory: "/tmp".to_string(),
             lines: vec![(0, 5), (8, 6)],
             labels: vec![("entrypoint".to_string(), 0, 4)],
+            lines_multi: Vec::new(),
+            labels_multi: Vec::new(),
             code_start: 0,
             code_end: 16,
         };

--- a/crates/assembler/src/debug.rs
+++ b/crates/assembler/src/debug.rs
@@ -138,25 +138,47 @@ fn generate_dwarf_sections(
         None,
     );
 
+    // Map from (filename, directory) to the raw DWARF file index.
+    // Built during line program registration and reused for
+    // DW_AT_decl_file on label DIEs. The main file is always index 0
+    // in DWARF v5; files added via `add_file` get indices 1, 2, ...
+    let mut file_index_map: std::collections::HashMap<(String, String), u32> =
+        std::collections::HashMap::new();
+
     if use_multi {
         use std::collections::HashMap;
 
+        // Pre-register the main file at index 0 — the LineProgram
+        // constructor already set it as the primary source file.
+        file_index_map.insert((data.filename.clone(), data.directory.clone()), 0);
+
         let mut dir_ids: HashMap<String, gimli::write::DirectoryId> = HashMap::new();
         let mut file_ids: HashMap<(String, String), gimli::write::FileId> = HashMap::new();
+        let mut next_file_idx = 1u32;
 
-        // Walk the lines once to register all (dir, file) entries in a
-        // stable order.
-        for (_, filename, directory, _) in &data.lines_multi {
+        // Register all (dir, file) entries from both lines_multi and
+        // labels_multi so that label-only files get a DWARF file index.
+        let all_file_refs = data
+            .lines_multi
+            .iter()
+            .map(|(_, f, d, _)| (f, d))
+            .chain(data.labels_multi.iter().map(|(_, _, f, d, _)| (f, d)));
+
+        for (filename, directory) in all_file_refs {
+            let key = (filename.clone(), directory.clone());
             let dir_id = *dir_ids.entry(directory.clone()).or_insert_with(|| {
                 let id = dwarf.line_strings.add(directory.clone().into_bytes());
                 line_program.add_directory(LineString::LineStringRef(id))
             });
-            file_ids
-                .entry((filename.clone(), directory.clone()))
-                .or_insert_with(|| {
-                    let id = dwarf.line_strings.add(filename.clone().into_bytes());
-                    line_program.add_file(LineString::LineStringRef(id), dir_id, None)
+            file_ids.entry(key.clone()).or_insert_with(|| {
+                let id = dwarf.line_strings.add(filename.clone().into_bytes());
+                file_index_map.entry(key).or_insert_with(|| {
+                    let idx = next_file_idx;
+                    next_file_idx += 1;
+                    idx
                 });
+                line_program.add_file(LineString::LineStringRef(id), dir_id, None)
+            });
         }
 
         line_program.begin_sequence(Some(Address::Constant(code_start)));
@@ -219,9 +241,9 @@ fn generate_dwarf_sections(
     );
     root.set(DW_AT_stmt_list, AttributeValue::LineProgramRef);
 
-    // Set labels.
+    // Add label DIEs.
     if use_multi {
-        for (name, address, _filename, _directory, line) in &data.labels_multi {
+        for (name, address, filename, directory, line) in &data.labels_multi {
             let adjusted_addr = address + text_offset;
             let label_id = dwarf.unit.add(root_id, DW_TAG_label);
             let label_die = dwarf.unit.get_mut(label_id);
@@ -230,11 +252,11 @@ fn generate_dwarf_sections(
                 DW_AT_name,
                 AttributeValue::String(name.clone().into_bytes()),
             );
-            // DW_AT_decl_file: we keep 0 for now (main file). Proper
-            // per-label file attribution would need mapping names back to
-            // file ids; step-debugger line mapping is the primary concern
-            // and uses the line program above.
-            label_die.set(DW_AT_decl_file, AttributeValue::Data4(0));
+            let decl_file = file_index_map
+                .get(&(filename.clone(), directory.clone()))
+                .copied()
+                .unwrap_or(0);
+            label_die.set(DW_AT_decl_file, AttributeValue::Data4(decl_file));
             label_die.set(DW_AT_decl_line, AttributeValue::Data4(*line));
             label_die.set(
                 DW_AT_low_pc,

--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -1,5 +1,24 @@
 use {crate::define_compile_errors, std::ops::Range};
 
+/// Multi-file context for a `DuplicateLabel` error produced during a
+/// multi-file assembly (i.e. a program that uses `.include`).
+///
+/// This is boxed inside `CompileError::DuplicateLabel` so that the
+/// single-file code path doesn't grow the enum variant and the whole
+/// `CompileError` stays small (keeping `Result<_, CompileError>` sizes
+/// from growing significantly).
+#[derive(Debug, Clone)]
+pub struct DuplicateLabelMulti {
+    /// File containing the duplicate (second) definition.
+    pub span_file: String,
+    /// File containing the original (first) definition.
+    pub original_span_file: String,
+    /// Chain of `.include` sites that led to the file containing the
+    /// duplicate, from the main file down. Empty when both definitions
+    /// are in the main file.
+    pub include_chain: Vec<(String, Range<usize>)>,
+}
+
 // labels could be overridden by passing a valid custom_label in the error variant
 // if not provided, the label will use default messages from below
 define_compile_errors! {
@@ -89,7 +108,12 @@ define_compile_errors! {
     DuplicateLabel {
         error = "Duplicate label '{label}'",
         label = "Label redefined",
-        fields = { label: String, span: Range<usize>, original_span: Range<usize> }
+        fields = {
+            label: String,
+            span: Range<usize>,
+            original_span: Range<usize>,
+            multi: Option<Box<DuplicateLabelMulti>>
+        }
     },
     BytecodeError {
         error = "Bytecode error: {error}",

--- a/crates/assembler/src/lib.rs
+++ b/crates/assembler/src/lib.rs
@@ -1,4 +1,8 @@
-use {anyhow::Result, codespan::Files};
+use {
+    anyhow::Result,
+    codespan::Files,
+    std::{collections::HashMap, path::Path},
+};
 
 // Parser
 pub mod parser;
@@ -28,7 +32,7 @@ pub use self::{
     astnode::ASTNode,
     debug::DebugData,
     errors::CompileError,
-    parser::{ParseResult, Token, parse},
+    parser::{ParseResult, Token, parse, parse_with_base_path},
     program::Program,
 };
 
@@ -71,6 +75,18 @@ pub struct AssemblerOption {
     pub debug_mode: Option<DebugMode>,
 }
 
+/// Result of `Assembler::assemble_with_base_path`. Carries the source
+/// registry populated by `.include` handling alongside the bytecode
+/// result, so callers can render multi-file diagnostics on error.
+pub struct AssembleResult {
+    /// Every source file read during parsing, keyed by the identifier
+    /// used in diagnostics (main file name or the relative `.include`
+    /// path). Populated on both success and failure.
+    pub sources: HashMap<String, String>,
+    /// The assembled bytecode, or a list of compile errors.
+    pub bytecode: Result<Vec<u8>, Vec<CompileError>>,
+}
+
 /// Assembler for SBPF assembly code
 #[derive(Debug, Clone)]
 pub struct Assembler {
@@ -83,6 +99,9 @@ impl Assembler {
         Self { options }
     }
 
+    /// Assemble a single source string. Does not support `.include`;
+    /// callers that need multi-file assembly should use
+    /// `assemble_with_base_path`.
     pub fn assemble(&self, source: &str) -> Result<Vec<u8>, Vec<CompileError>> {
         let parse_result = match parse(source, self.options.arch) {
             Ok(result) => result,
@@ -101,6 +120,8 @@ impl Assembler {
                 directory: debug_mode.directory.clone(),
                 lines,
                 labels,
+                lines_multi: Vec::new(),
+                labels_multi: Vec::new(),
                 code_start: 0,
                 code_end,
             })
@@ -112,12 +133,82 @@ impl Assembler {
         let bytecode = program.emit_bytecode();
         Ok(bytecode)
     }
+
+    /// Assemble `source` with `.include` support.
+    ///
+    /// * `main_file_name` — identifier used for the main file in
+    ///   diagnostics and DWARF debug info (typically the file's basename).
+    /// * `source` — contents of the main file.
+    /// * `base_path` — directory used to resolve `.include` paths in the
+    ///   main file (nested includes are resolved relative to the
+    ///   including file's directory).
+    ///
+    /// Returns `AssembleResult` with the full source registry (main plus
+    /// every file pulled in via `.include`) so callers can produce
+    /// multi-file diagnostics even when assembly fails. The registry is
+    /// populated in both the success and failure paths.
+    pub fn assemble_with_base_path(
+        &self,
+        main_file_name: &str,
+        source: &str,
+        base_path: &Path,
+    ) -> AssembleResult {
+        let mut sources: HashMap<String, String> = HashMap::new();
+        let parse_result = match parse_with_base_path(
+            source,
+            self.options.arch,
+            Some(base_path),
+            main_file_name,
+            &mut sources,
+        ) {
+            Ok(result) => result,
+            Err(errors) => {
+                // Parsing failed. `sources` has every file read during
+                // parsing (main + any included files that were read
+                // before the error), so multi-file diagnostics can still
+                // be rendered by the caller.
+                return AssembleResult {
+                    sources,
+                    bytecode: Err(errors),
+                };
+            }
+        };
+
+        let debug_data = if let Some(ref debug_mode) = self.options.debug_mode {
+            let (lines, labels, lines_multi, labels_multi) =
+                collect_multi_file_line_entries(&parse_result, debug_mode);
+            let code_end = parse_result.code_section.get_size();
+
+            Some(DebugData {
+                filename: debug_mode.filename.clone(),
+                directory: debug_mode.directory.clone(),
+                lines,
+                labels,
+                lines_multi,
+                labels_multi,
+                code_start: 0,
+                code_end,
+            })
+        } else {
+            None
+        };
+
+        let program = Program::from_parse_result(parse_result, debug_data);
+        let bytecode = program.emit_bytecode();
+        AssembleResult {
+            sources,
+            bytecode: Ok(bytecode),
+        }
+    }
 }
 
 type LineEntry = (u64, u32); // (offset, line)
 type LabelEntry = (String, u64, u32); // (label, offset, line)
+type LineMultiEntry = (u64, String, String, u32); // (offset, file, dir, line)
+type LabelMultiEntry = (String, u64, String, String, u32); // (name, offset, file, dir, line)
 
-/// Helper function to collect line and label entries
+/// Helper function to collect line and label entries for single-file
+/// sources (no `.include`).
 fn collect_line_and_label_entries(
     source: &str,
     parse_result: &ParseResult,
@@ -156,6 +247,142 @@ fn collect_line_and_label_entries(
     }
 
     (line_entries, label_entries)
+}
+
+/// Collect line and label entries for a multi-file parse result.
+///
+/// Returns four vectors: the single-file `lines`/`labels` (always based
+/// on the main source for backwards compatibility with consumers that
+/// only read those), plus `lines_multi`/`labels_multi` which carry per-
+/// instruction file/line info drawn from every included file.
+///
+/// `parse_result.code_file_info` / `rodata_file_info` / `label_file_info`
+/// are the parallel maps populated by the parser; this function builds
+/// `codespan::Files` over each distinct source so line numbers are
+/// relative to the owning file (not a merged view).
+fn collect_multi_file_line_entries(
+    parse_result: &ParseResult,
+    debug_mode: &DebugMode,
+) -> (
+    Vec<LineEntry>,
+    Vec<LabelEntry>,
+    Vec<LineMultiEntry>,
+    Vec<LabelMultiEntry>,
+) {
+    use std::collections::HashMap;
+
+    // Build a Files index over every source we read.
+    let mut files: Files<String> = Files::new();
+    let mut file_ids: HashMap<String, codespan::FileId> = HashMap::new();
+    for (name, content) in &parse_result.sources {
+        let id = files.add(name.clone(), content.clone());
+        file_ids.insert(name.clone(), id);
+    }
+
+    let mut offset_to_file: HashMap<u64, String> = HashMap::new();
+    for (offset, file) in &parse_result.code_file_info {
+        offset_to_file.insert(*offset, file.clone());
+    }
+    let mut rodata_offset_to_file: HashMap<u64, String> = HashMap::new();
+    for (offset, file) in &parse_result.rodata_file_info {
+        rodata_offset_to_file.insert(*offset, file.clone());
+    }
+
+    let main_name = debug_mode.filename.clone();
+    let main_dir = debug_mode.directory.clone();
+
+    let mut lines = Vec::new();
+    let mut labels = Vec::new();
+    let mut lines_multi = Vec::new();
+    let mut labels_multi = Vec::new();
+
+    // Code section: instructions and labels.
+    for node in parse_result.code_section.get_nodes() {
+        match node {
+            ASTNode::Instruction {
+                instruction,
+                offset,
+            } => {
+                let file = offset_to_file
+                    .get(offset)
+                    .cloned()
+                    .unwrap_or_else(|| main_name.clone());
+                if let Some(file_id) = file_ids.get(&file) {
+                    let line_index = files.line_index(*file_id, instruction.span.start as u32);
+                    let line_number = (line_index.to_usize() + 1) as u32;
+                    // Always populate single-file view (treats everything
+                    // as main file) for backwards compat.
+                    lines.push((*offset, line_number));
+                    // Multi-file view with real file name.
+                    let (filename, directory) = split_file_and_dir(&file, &main_name, &main_dir);
+                    lines_multi.push((*offset, filename, directory, line_number));
+                }
+            }
+            ASTNode::Label { label, offset } => {
+                let file = parse_result
+                    .label_file_info
+                    .get(&label.name)
+                    .cloned()
+                    .unwrap_or_else(|| main_name.clone());
+                if let Some(file_id) = file_ids.get(&file) {
+                    let line_index = files.line_index(*file_id, label.span.start as u32);
+                    let line_number = (line_index.to_usize() + 1) as u32;
+                    labels.push((label.name.clone(), *offset, line_number));
+                    let (filename, directory) = split_file_and_dir(&file, &main_name, &main_dir);
+                    labels_multi.push((
+                        label.name.clone(),
+                        *offset,
+                        filename,
+                        directory,
+                        line_number,
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // ROData: also contribute label entries keyed by their own offset.
+    for node in parse_result.data_section.get_nodes() {
+        if let ASTNode::ROData { rodata, offset } = node {
+            let file = parse_result
+                .label_file_info
+                .get(&rodata.name)
+                .cloned()
+                .or_else(|| rodata_offset_to_file.get(offset).cloned())
+                .unwrap_or_else(|| main_name.clone());
+            if let Some(file_id) = file_ids.get(&file) {
+                let line_index = files.line_index(*file_id, rodata.span.start as u32);
+                let line_number = (line_index.to_usize() + 1) as u32;
+                labels.push((rodata.name.clone(), *offset, line_number));
+                let (filename, directory) = split_file_and_dir(&file, &main_name, &main_dir);
+                labels_multi.push((
+                    rodata.name.clone(),
+                    *offset,
+                    filename,
+                    directory,
+                    line_number,
+                ));
+            }
+        }
+    }
+
+    (lines, labels, lines_multi, labels_multi)
+}
+
+/// Split a parser file identifier into `(filename, directory)` for DWARF.
+///
+/// The main file uses the directory passed in `DebugMode`. Included files
+/// are reported as `(relative_path, main_dir)` — the relative path acts as
+/// the filename since that is how the user referenced the file. This
+/// keeps the DWARF line table self-consistent without needing to canonicalize
+/// absolute paths.
+fn split_file_and_dir(file: &str, main_name: &str, main_dir: &str) -> (String, String) {
+    if file == main_name {
+        (main_name.to_string(), main_dir.to_string())
+    } else {
+        (file.to_string(), main_dir.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/crates/assembler/src/lib.rs
+++ b/crates/assembler/src/lib.rs
@@ -112,7 +112,8 @@ impl Assembler {
 
         // Build debug data if debug mode is enabled
         let debug_data = if let Some(ref debug_mode) = self.options.debug_mode {
-            let (lines, labels) = collect_line_and_label_entries(source, &parse_result);
+            let (lines, labels, lines_multi, labels_multi) =
+                collect_debug_entries(&parse_result, debug_mode);
             let code_end = parse_result.code_section.get_size();
 
             Some(DebugData {
@@ -120,8 +121,8 @@ impl Assembler {
                 directory: debug_mode.directory.clone(),
                 lines,
                 labels,
-                lines_multi: Vec::new(),
-                labels_multi: Vec::new(),
+                lines_multi,
+                labels_multi,
                 code_start: 0,
                 code_end,
             })
@@ -176,7 +177,7 @@ impl Assembler {
 
         let debug_data = if let Some(ref debug_mode) = self.options.debug_mode {
             let (lines, labels, lines_multi, labels_multi) =
-                collect_multi_file_line_entries(&parse_result, debug_mode);
+                collect_debug_entries(&parse_result, debug_mode);
             let code_end = parse_result.code_section.get_size();
 
             Some(DebugData {
@@ -207,60 +208,14 @@ type LabelEntry = (String, u64, u32); // (label, offset, line)
 type LineMultiEntry = (u64, String, String, u32); // (offset, file, dir, line)
 type LabelMultiEntry = (String, u64, String, String, u32); // (name, offset, file, dir, line)
 
-/// Helper function to collect line and label entries for single-file
-/// sources (no `.include`).
-fn collect_line_and_label_entries(
-    source: &str,
-    parse_result: &ParseResult,
-) -> (Vec<LineEntry>, Vec<LabelEntry>) {
-    let mut files: Files<&str> = Files::new();
-    let file_id = files.add("source", source);
-
-    let mut line_entries = Vec::new();
-    let mut label_entries = Vec::new();
-
-    for node in parse_result.code_section.get_nodes() {
-        match node {
-            ASTNode::Instruction {
-                instruction,
-                offset,
-            } => {
-                let line_index = files.line_index(file_id, instruction.span.start as u32);
-                let line_number = (line_index.to_usize() + 1) as u32;
-                line_entries.push((*offset, line_number));
-            }
-            ASTNode::Label { label, offset } => {
-                let line_index = files.line_index(file_id, label.span.start as u32);
-                let line_number = (line_index.to_usize() + 1) as u32;
-                label_entries.push((label.name.clone(), *offset, line_number));
-            }
-            _ => {}
-        }
-    }
-
-    for node in parse_result.data_section.get_nodes() {
-        if let ASTNode::ROData { rodata, offset } = node {
-            let line_index = files.line_index(file_id, rodata.span.start as u32);
-            let line_number = (line_index.to_usize() + 1) as u32;
-            label_entries.push((rodata.name.clone(), *offset, line_number));
-        }
-    }
-
-    (line_entries, label_entries)
-}
-
-/// Collect line and label entries for a multi-file parse result.
+/// Collect line and label entries from a parse result.
 ///
-/// Returns four vectors: the single-file `lines`/`labels` (always based
-/// on the main source for backwards compatibility with consumers that
-/// only read those), plus `lines_multi`/`labels_multi` which carry per-
-/// instruction file/line info drawn from every included file.
-///
-/// `parse_result.code_file_info` / `rodata_file_info` / `label_file_info`
-/// are the parallel maps populated by the parser; this function builds
-/// `codespan::Files` over each distinct source so line numbers are
-/// relative to the owning file (not a merged view).
-fn collect_multi_file_line_entries(
+/// Works for both single-file and multi-file assemblies: each `ASTNode`
+/// carries an optional `file` field set by the parser. When the file
+/// field differs across nodes (i.e. `.include` was used), this function
+/// returns populated `lines_multi`/`labels_multi` vectors in addition to
+/// the single-file `lines`/`labels`.
+fn collect_debug_entries(
     parse_result: &ParseResult,
     debug_mode: &DebugMode,
 ) -> (
@@ -269,8 +224,6 @@ fn collect_multi_file_line_entries(
     Vec<LineMultiEntry>,
     Vec<LabelMultiEntry>,
 ) {
-    use std::collections::HashMap;
-
     // Build a Files index over every source we read.
     let mut files: Files<String> = Files::new();
     let mut file_ids: HashMap<String, codespan::FileId> = HashMap::new();
@@ -279,17 +232,9 @@ fn collect_multi_file_line_entries(
         file_ids.insert(name.clone(), id);
     }
 
-    let mut offset_to_file: HashMap<u64, String> = HashMap::new();
-    for (offset, file) in &parse_result.code_file_info {
-        offset_to_file.insert(*offset, file.clone());
-    }
-    let mut rodata_offset_to_file: HashMap<u64, String> = HashMap::new();
-    for (offset, file) in &parse_result.rodata_file_info {
-        rodata_offset_to_file.insert(*offset, file.clone());
-    }
-
-    let main_name = debug_mode.filename.clone();
-    let main_dir = debug_mode.directory.clone();
+    let main_name = &debug_mode.filename;
+    let main_dir = &debug_mode.directory;
+    let has_multi = parse_result.sources.len() > 1;
 
     let mut lines = Vec::new();
     let mut labels = Vec::new();
@@ -302,87 +247,75 @@ fn collect_multi_file_line_entries(
             ASTNode::Instruction {
                 instruction,
                 offset,
+                file,
             } => {
-                let file = offset_to_file
-                    .get(offset)
-                    .cloned()
-                    .unwrap_or_else(|| main_name.clone());
-                if let Some(file_id) = file_ids.get(&file) {
+                let f = file.as_deref().unwrap_or(main_name);
+                if let Some(file_id) = file_ids.get(f) {
                     let line_index = files.line_index(*file_id, instruction.span.start as u32);
                     let line_number = (line_index.to_usize() + 1) as u32;
-                    // Always populate single-file view (treats everything
-                    // as main file) for backwards compat.
                     lines.push((*offset, line_number));
-                    // Multi-file view with real file name.
-                    let (filename, directory) = split_file_and_dir(&file, &main_name, &main_dir);
-                    lines_multi.push((*offset, filename, directory, line_number));
+                    if has_multi {
+                        lines_multi.push((
+                            *offset,
+                            f.to_string(),
+                            main_dir.to_string(),
+                            line_number,
+                        ));
+                    }
                 }
             }
-            ASTNode::Label { label, offset } => {
-                let file = parse_result
-                    .label_file_info
-                    .get(&label.name)
-                    .cloned()
-                    .unwrap_or_else(|| main_name.clone());
-                if let Some(file_id) = file_ids.get(&file) {
+            ASTNode::Label {
+                label,
+                offset,
+                file,
+            } => {
+                let f = file.as_deref().unwrap_or(main_name);
+                if let Some(file_id) = file_ids.get(f) {
                     let line_index = files.line_index(*file_id, label.span.start as u32);
                     let line_number = (line_index.to_usize() + 1) as u32;
                     labels.push((label.name.clone(), *offset, line_number));
-                    let (filename, directory) = split_file_and_dir(&file, &main_name, &main_dir);
-                    labels_multi.push((
-                        label.name.clone(),
-                        *offset,
-                        filename,
-                        directory,
-                        line_number,
-                    ));
+                    if has_multi {
+                        labels_multi.push((
+                            label.name.clone(),
+                            *offset,
+                            f.to_string(),
+                            main_dir.to_string(),
+                            line_number,
+                        ));
+                    }
                 }
             }
             _ => {}
         }
     }
 
-    // ROData: also contribute label entries keyed by their own offset.
+    // ROData labels.
     for node in parse_result.data_section.get_nodes() {
-        if let ASTNode::ROData { rodata, offset } = node {
-            let file = parse_result
-                .label_file_info
-                .get(&rodata.name)
-                .cloned()
-                .or_else(|| rodata_offset_to_file.get(offset).cloned())
-                .unwrap_or_else(|| main_name.clone());
-            if let Some(file_id) = file_ids.get(&file) {
+        if let ASTNode::ROData {
+            rodata,
+            offset,
+            file,
+        } = node
+        {
+            let f = file.as_deref().unwrap_or(main_name);
+            if let Some(file_id) = file_ids.get(f) {
                 let line_index = files.line_index(*file_id, rodata.span.start as u32);
                 let line_number = (line_index.to_usize() + 1) as u32;
                 labels.push((rodata.name.clone(), *offset, line_number));
-                let (filename, directory) = split_file_and_dir(&file, &main_name, &main_dir);
-                labels_multi.push((
-                    rodata.name.clone(),
-                    *offset,
-                    filename,
-                    directory,
-                    line_number,
-                ));
+                if has_multi {
+                    labels_multi.push((
+                        rodata.name.clone(),
+                        *offset,
+                        f.to_string(),
+                        main_dir.to_string(),
+                        line_number,
+                    ));
+                }
             }
         }
     }
 
     (lines, labels, lines_multi, labels_multi)
-}
-
-/// Split a parser file identifier into `(filename, directory)` for DWARF.
-///
-/// The main file uses the directory passed in `DebugMode`. Included files
-/// are reported as `(relative_path, main_dir)` — the relative path acts as
-/// the filename since that is how the user referenced the file. This
-/// keeps the DWARF line table self-consistent without needing to canonicalize
-/// absolute paths.
-fn split_file_and_dir(file: &str, main_name: &str, main_dir: &str) -> (String, String) {
-    if file == main_name {
-        (main_name.to_string(), main_dir.to_string())
-    } else {
-        (file.to_string(), main_dir.to_string())
-    }
 }
 
 #[cfg(test)]
@@ -605,6 +538,53 @@ entrypoint:
         assert!(
             bytecode_str.contains(".debug_line_str"),
             "Missing .debug_line_str section"
+        );
+    }
+
+    #[test]
+    fn test_nested_include_uses_root_relative_keys() {
+        use std::fs;
+
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let src = tmp.path().join("src");
+        let modules = src.join("modules");
+        fs::create_dir_all(&modules).unwrap();
+
+        fs::write(
+            src.join("test.s"),
+            ".globl entrypoint\n.include \"modules/a.s\"\nentrypoint:\n    call my_func\n    \
+             exit\n",
+        )
+        .unwrap();
+
+        fs::write(modules.join("a.s"), ".include \"b.s\"\n").unwrap();
+
+        fs::write(modules.join("b.s"), "my_func:\n    mov64 r0, 0\n    exit\n").unwrap();
+
+        let main_source = fs::read_to_string(src.join("test.s")).unwrap();
+        let assembler = Assembler::new(AssemblerOption::default());
+        let result = assembler.assemble_with_base_path("test.s", &main_source, &src);
+
+        assert!(
+            result.bytecode.is_ok(),
+            "assembly failed: {:?}",
+            result.bytecode.unwrap_err()
+        );
+
+        assert!(
+            result.sources.contains_key("modules/a.s"),
+            "sources should contain root-relative key 'modules/a.s', got: {:?}",
+            result.sources.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            result.sources.contains_key("modules/b.s"),
+            "sources should contain root-relative key 'modules/b.s', got: {:?}",
+            result.sources.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            result.sources.contains_key("test.s"),
+            "sources should contain key 'test.s', got: {:?}",
+            result.sources.keys().collect::<Vec<_>>()
         );
     }
 }

--- a/crates/assembler/src/macros.rs
+++ b/crates/assembler/src/macros.rs
@@ -13,7 +13,7 @@ macro_rules! define_compile_errors {
         pub enum CompileError {
             $(
                 #[error($error_msg)]
-                $variant { $( $field_name: $field_ty ),*, custom_label: Option<String> }
+                $variant { $( $field_name: $field_ty ),*, custom_label: Option<String>, file: Option<String> }
             ),*
         }
 
@@ -31,6 +31,25 @@ macro_rules! define_compile_errors {
                     $(
                         Self::$variant { span, .. } => span,
                     )*
+                }
+            }
+
+            pub fn file(&self) -> Option<&str> {
+                match self {
+                    $(
+                        Self::$variant { file, .. } => file.as_deref(),
+                    )*
+                }
+            }
+
+            pub fn with_file(self, f: &str) -> Self {
+                match self {
+                    $(
+                        Self::$variant { file: None, $( $field_name ),*, custom_label } => {
+                            Self::$variant { $( $field_name ),*, custom_label, file: Some(f.to_string()) }
+                        }
+                    ),*,
+                    other => other,
                 }
             }
         }
@@ -74,17 +93,28 @@ mod tests {
         let err1 = CompileError::TestError1 {
             span: 0..10,
             custom_label: None,
+            file: None,
         };
         assert_eq!(err1.label(), "test label 1");
         assert_eq!(err1.span(), &(0..10));
         assert_eq!(err1.to_string(), "Test error 1");
+        assert_eq!(err1.file(), None);
+
+        let err1 = err1.with_file("test.s");
+        assert_eq!(err1.file(), Some("test.s"));
 
         let err2 = CompileError::TestError2 {
             span: 5..15,
             message: "custom message".to_string(),
             custom_label: Some("custom".to_string()),
+            file: Some("main.s".to_string()),
         };
         assert_eq!(err2.label(), "custom");
         assert_eq!(err2.span(), &(5..15));
+        assert_eq!(err2.file(), Some("main.s"));
+
+        // with_file should not overwrite existing file
+        let err2 = err2.with_file("other.s");
+        assert_eq!(err2.file(), Some("main.s"));
     }
 }

--- a/crates/assembler/src/parser/common.rs
+++ b/crates/assembler/src/parser/common.rs
@@ -24,6 +24,7 @@ pub fn parse_register(pair: Pair<Rule>) -> Result<Register, CompileError> {
             register: reg_str.to_string(),
             span: span.start()..span.end(),
             custom_label: None,
+            file: None,
         })
     }
 }
@@ -73,6 +74,7 @@ pub fn parse_operand(
     Err(CompileError::ParseError {
         error: "Invalid operand".to_string(),
         span: span_range,
+        file: None,
         custom_label: None,
     })
 }
@@ -100,6 +102,7 @@ pub fn parse_jump_target(
     Err(CompileError::ParseError {
         error: "Invalid jump target".to_string(),
         span: span_range,
+        file: None,
         custom_label: None,
     })
 }
@@ -185,6 +188,7 @@ pub fn parse_number(pair: Pair<Rule>) -> Result<Number, CompileError> {
         number: number_str,
         span: span_range,
         custom_label: None,
+        file: None,
     })
 }
 
@@ -247,6 +251,7 @@ pub fn process_endian(
                         .map_err(|_| CompileError::ParseError {
                             error: format!("Invalid endian size in '{}'", op_str),
                             span: inner_span.start()..inner_span.end(),
+                            file: None,
                             custom_label: None,
                         })?;
                     (Opcode::Be, size)
@@ -256,6 +261,7 @@ pub fn process_endian(
                         .map_err(|_| CompileError::ParseError {
                             error: format!("Invalid endian size in '{}'", op_str),
                             span: inner_span.start()..inner_span.end(),
+                            file: None,
                             custom_label: None,
                         })?;
                     (Opcode::Le, size)
@@ -263,6 +269,7 @@ pub fn process_endian(
                     return Err(CompileError::ParseError {
                         error: format!("Invalid endian operation '{}'", op_str),
                         span: inner_span.start()..inner_span.end(),
+                        file: None,
                         custom_label: None,
                     });
                 };

--- a/crates/assembler/src/parser/default.rs
+++ b/crates/assembler/src/parser/default.rs
@@ -44,6 +44,7 @@ pub(crate) fn process_instruction(
     Err(CompileError::ParseError {
         error: "Invalid instruction".to_string(),
         span: outer_span_range,
+        file: None,
         custom_label: None,
     })
 }
@@ -199,6 +200,7 @@ fn process_alu_reg(
                                     error: format!("Invalid opcode 0x{:02x}: {}", reg_opcode, e),
                                     span: inner_span.start()..inner_span.end(),
                                     custom_label: None,
+                                    file: None,
                                 })?,
                         );
                 }
@@ -279,6 +281,7 @@ fn process_jump_reg(
                                     error: format!("Invalid opcode 0x{:02x}: {}", reg_opcode, e),
                                     span: inner_span.start()..inner_span.end(),
                                     custom_label: None,
+                                    file: None,
                                 })?,
                         );
                 }

--- a/crates/assembler/src/parser/directive.rs
+++ b/crates/assembler/src/parser/directive.rs
@@ -1,5 +1,8 @@
 use {
-    super::{IncludeSite, ParseContext, Rule, Token, common::parse_number, process_source},
+    super::{
+        ParseContext, Rule, SourceLocation, Token, attach_file_to_error, common::parse_number,
+        process_source,
+    },
     crate::{
         astnode::{ASTNode, ExternDecl, GlobalDecl, ROData, RodataDecl},
         errors::CompileError,
@@ -62,7 +65,7 @@ pub fn process_directive_inner(pair: Pair<Rule>, ctx: &mut ParseContext) {
                         }
                         Rule::expression => match eval_expression(equ_inner, ctx.const_map) {
                             Ok(v) => value = Some(v),
-                            Err(e) => ctx.errors.push(e),
+                            Err(e) => ctx.errors.push(attach_file_to_error(e, &ctx.current_file)),
                         },
                         _ => {}
                     }
@@ -103,11 +106,14 @@ pub fn process_directive_inner(pair: Pair<Rule>, ctx: &mut ParseContext) {
 /// the `.include` directive. Nested includes are supported: an included
 /// file may itself use `.include` with paths relative to its own location.
 ///
-/// The current file name (`ctx.current_file`) and base path are swapped
-/// for the duration of the recursive parse, and the `.include` site is
-/// pushed onto `ctx.include_stack` so diagnostics (e.g. `DuplicateLabel`)
-/// can annotate errors with the chain of `.include` directives that led
-/// to the problem.
+/// Cyclic includes are detected via `ctx.include_set` — a set of
+/// canonicalized paths currently being parsed. If a cycle is found, a
+/// compile error is emitted instead of recursing.
+///
+/// The file identifier used in diagnostics and debug info is the path
+/// relative to the project root (the original `base_path` passed to
+/// `parse_with_base_path`), so that `modules/a.s` including `b.s`
+/// registers as `modules/b.s`, not just `b.s`.
 fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
     let span = pair.as_span();
     let include_span = span.start()..span.end();
@@ -131,6 +137,7 @@ fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
             ctx.errors.push(CompileError::ParseError {
                 error: "Invalid .include directive: expected \"path\"".to_string(),
                 span: include_span,
+                file: Some(ctx.current_file.clone()),
                 custom_label: None,
             });
             return;
@@ -143,17 +150,35 @@ fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
         None => {
             ctx.errors.push(CompileError::ParseError {
                 error: format!(
-                    "Cannot resolve .include \"{}\": no base path available. \
-                     Use assemble_with_base_path to enable .include support.",
+                    "Cannot resolve .include \"{}\": no base path available. Use \
+                     assemble_with_base_path to enable .include support.",
                     path
                 ),
                 span: include_span,
+                file: Some(ctx.current_file.clone()),
                 custom_label: None,
             });
             return;
         }
     };
     let include_path = base.join(&path);
+
+    // Cycle detection: canonicalize the path and check the include set.
+    let canonical = include_path
+        .canonicalize()
+        .unwrap_or_else(|_| include_path.clone());
+    if ctx.include_set.contains(&canonical) {
+        ctx.errors.push(CompileError::ParseError {
+            error: format!(
+                "Cyclic include detected: \"{}\" is already being parsed",
+                path
+            ),
+            span: include_span,
+            file: Some(ctx.current_file.clone()),
+            custom_label: Some("cyclic include".to_string()),
+        });
+        return;
+    }
 
     // Read the included file.
     let content = match fs::read_to_string(&include_path) {
@@ -162,15 +187,24 @@ fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
             ctx.errors.push(CompileError::ParseError {
                 error: format!("Failed to read include \"{}\": {}", path, e),
                 span: include_span,
+                file: Some(ctx.current_file.clone()),
                 custom_label: None,
             });
             return;
         }
     };
 
-    // Normalize the identifier we use for this file in diagnostics and
-    // debug info: the path as written, with any `./` prefix stripped.
-    let include_id = path.trim_start_matches("./").to_string();
+    // Build the file identifier relative to the project root so that
+    // nested paths are correct (e.g. `modules/b.s` instead of `b.s`).
+    let include_id = if let Some(root) = &ctx.root_base_path {
+        canonical
+            .strip_prefix(root)
+            .unwrap_or(&canonical)
+            .to_string_lossy()
+            .to_string()
+    } else {
+        path.trim_start_matches("./").to_string()
+    };
 
     // Register the file content (skip if already read via an earlier
     // include of the same path — this is harmless because duplicate label
@@ -187,10 +221,11 @@ fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
         .unwrap_or_else(|| PathBuf::from("."));
 
     // Push the include site, swap in the new context, recurse, restore.
-    ctx.include_stack.push(IncludeSite {
+    ctx.include_stack.push(SourceLocation {
         file: ctx.current_file.clone(),
         span: include_span,
     });
+    ctx.include_set.insert(canonical.clone());
     let old_base = ctx.base_path.replace(new_base);
     let old_file = std::mem::replace(&mut ctx.current_file, include_id);
 
@@ -198,6 +233,7 @@ fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
 
     ctx.current_file = old_file;
     ctx.base_path = old_base;
+    ctx.include_set.remove(&canonical);
     ctx.include_stack.pop();
 }
 
@@ -214,6 +250,7 @@ pub fn process_rodata_directive(
             .ok_or_else(|| CompileError::ParseError {
                 error: "No directive content found".to_string(),
                 span: label_span.clone(),
+                file: None,
                 custom_label: None,
             })?
     };
@@ -291,6 +328,7 @@ pub fn process_rodata_directive(
     Err(CompileError::InvalidRodataDecl {
         span: label_span,
         custom_label: None,
+        file: None,
     })
 }
 
@@ -336,6 +374,7 @@ fn eval_expression(
     stack.pop().ok_or_else(|| CompileError::ParseError {
         error: "Invalid expression".to_string(),
         span: span_range,
+        file: None,
         custom_label: None,
     })
 }
@@ -363,6 +402,7 @@ fn eval_term(
                 return Err(CompileError::ParseError {
                     error: format!("Undefined constant: {}", name),
                     span: inner.as_span().start()..inner.as_span().end(),
+                    file: None,
                     custom_label: None,
                 });
             }
@@ -373,6 +413,7 @@ fn eval_term(
     Err(CompileError::ParseError {
         error: "Invalid term".to_string(),
         span: span_range,
+        file: None,
         custom_label: None,
     })
 }

--- a/crates/assembler/src/parser/directive.rs
+++ b/crates/assembler/src/parser/directive.rs
@@ -1,12 +1,12 @@
 use {
-    super::{ParseContext, Rule, Token, common::parse_number},
+    super::{IncludeSite, ParseContext, Rule, Token, common::parse_number, process_source},
     crate::{
         astnode::{ASTNode, ExternDecl, GlobalDecl, ROData, RodataDecl},
         errors::CompileError,
     },
     pest::iterators::Pair,
     sbpf_common::inst_param::Number,
-    std::collections::HashMap,
+    std::{collections::HashMap, fs, path::PathBuf},
 };
 
 pub fn process_directive_statement(pair: Pair<Rule>, ctx: &mut ParseContext) {
@@ -88,9 +88,117 @@ pub fn process_directive_inner(pair: Pair<Rule>, ctx: &mut ParseContext) {
                     _ => {}
                 }
             }
+            Rule::directive_include => {
+                process_directive_include(inner, ctx);
+            }
             _ => {}
         }
     }
+}
+
+/// Handle `.include "path"` by reading the referenced file and parsing it
+/// into the same `ParseContext` so its nodes are merged into one AST.
+///
+/// Paths are resolved relative to the directory of the file containing
+/// the `.include` directive. Nested includes are supported: an included
+/// file may itself use `.include` with paths relative to its own location.
+///
+/// The current file name (`ctx.current_file`) and base path are swapped
+/// for the duration of the recursive parse, and the `.include` site is
+/// pushed onto `ctx.include_stack` so diagnostics (e.g. `DuplicateLabel`)
+/// can annotate errors with the chain of `.include` directives that led
+/// to the problem.
+fn process_directive_include(pair: Pair<Rule>, ctx: &mut ParseContext) {
+    let span = pair.as_span();
+    let include_span = span.start()..span.end();
+
+    // Extract the `"path"` string literal content.
+    let mut raw_path: Option<String> = None;
+    for inner in pair.into_inner() {
+        if inner.as_rule() == Rule::string_literal {
+            for lit_inner in inner.into_inner() {
+                if lit_inner.as_rule() == Rule::string_content {
+                    raw_path = Some(lit_inner.as_str().to_string());
+                    break;
+                }
+            }
+        }
+    }
+
+    let path = match raw_path {
+        Some(p) => p,
+        None => {
+            ctx.errors.push(CompileError::ParseError {
+                error: "Invalid .include directive: expected \"path\"".to_string(),
+                span: include_span,
+                custom_label: None,
+            });
+            return;
+        }
+    };
+
+    // Resolve the path relative to the including file's directory.
+    let base = match &ctx.base_path {
+        Some(b) => b.clone(),
+        None => {
+            ctx.errors.push(CompileError::ParseError {
+                error: format!(
+                    "Cannot resolve .include \"{}\": no base path available. \
+                     Use assemble_with_base_path to enable .include support.",
+                    path
+                ),
+                span: include_span,
+                custom_label: None,
+            });
+            return;
+        }
+    };
+    let include_path = base.join(&path);
+
+    // Read the included file.
+    let content = match fs::read_to_string(&include_path) {
+        Ok(c) => c,
+        Err(e) => {
+            ctx.errors.push(CompileError::ParseError {
+                error: format!("Failed to read include \"{}\": {}", path, e),
+                span: include_span,
+                custom_label: None,
+            });
+            return;
+        }
+    };
+
+    // Normalize the identifier we use for this file in diagnostics and
+    // debug info: the path as written, with any `./` prefix stripped.
+    let include_id = path.trim_start_matches("./").to_string();
+
+    // Register the file content (skip if already read via an earlier
+    // include of the same path — this is harmless because duplicate label
+    // detection catches re-parses).
+    ctx.files
+        .entry(include_id.clone())
+        .or_insert_with(|| content.clone());
+
+    // Compute the new base path for nested includes inside the included
+    // file: paths are relative to the included file's own directory.
+    let new_base: PathBuf = include_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Push the include site, swap in the new context, recurse, restore.
+    ctx.include_stack.push(IncludeSite {
+        file: ctx.current_file.clone(),
+        span: include_span,
+    });
+    let old_base = ctx.base_path.replace(new_base);
+    let old_file = std::mem::replace(&mut ctx.current_file, include_id);
+
+    process_source(&content, ctx);
+
+    ctx.current_file = old_file;
+    ctx.base_path = old_base;
+    ctx.include_stack.pop();
 }
 
 pub fn process_rodata_directive(

--- a/crates/assembler/src/parser/llvm.rs
+++ b/crates/assembler/src/parser/llvm.rs
@@ -46,6 +46,7 @@ pub(crate) fn process_instruction(
     Err(CompileError::ParseError {
         error: "Invalid LLVM instruction".to_string(),
         span: outer_span_range,
+        file: None,
         custom_label: None,
     })
 }
@@ -130,6 +131,7 @@ fn process_alu(
         resolve_alu_opcode(op_str, is_64bit).ok_or_else(|| CompileError::ParseError {
             error: format!("Unknown ALU operator: {}", op_str),
             span: span.clone(),
+            file: None,
             custom_label: None,
         })?;
 
@@ -142,6 +144,7 @@ fn process_alu(
                 error: format!("Invalid opcode 0x{:02x}: {}", reg_opcode_byte, e),
                 span: span.clone(),
                 custom_label: None,
+                file: None,
             })?;
     }
 
@@ -210,6 +213,7 @@ fn process_load(
             CompileError::ParseError {
                 error: "Invalid memory size for load".to_string(),
                 span: span.clone(),
+                file: None,
                 custom_label: None,
             }
         })?;
@@ -252,6 +256,7 @@ fn process_store_imm(
             CompileError::ParseError {
                 error: "Invalid memory size for store".to_string(),
                 span: span.clone(),
+                file: None,
                 custom_label: None,
             }
         })?;
@@ -294,6 +299,7 @@ fn process_store_reg(
             CompileError::ParseError {
                 error: "Invalid memory size for store".to_string(),
                 span: span.clone(),
+                file: None,
                 custom_label: None,
             }
         })?;
@@ -359,6 +365,7 @@ fn process_jump_reg(
     let imm_opcode = resolve_cmp_opcode(op_str).ok_or_else(|| CompileError::ParseError {
         error: format!("Unknown comparison operator: {}", op_str),
         span: span.clone(),
+        file: None,
         custom_label: None,
     })?;
     // Convert Imm variant to Reg variant using BPF_X flag
@@ -369,6 +376,7 @@ fn process_jump_reg(
             error: format!("Invalid opcode 0x{:02x}: {}", reg_opcode_byte, e),
             span: span.clone(),
             custom_label: None,
+            file: None,
         })?;
 
     Ok(Instruction {
@@ -405,6 +413,7 @@ fn process_jump_imm(
     let opcode = resolve_cmp_opcode(op_str).ok_or_else(|| CompileError::ParseError {
         error: format!("Unknown comparison operator: {}", op_str),
         span: span.clone(),
+        file: None,
         custom_label: None,
     })?;
 

--- a/crates/assembler/src/parser/mod.rs
+++ b/crates/assembler/src/parser/mod.rs
@@ -17,7 +17,7 @@ use {
     pest_derive::Parser,
     sbpf_common::{inst_param::Number, instruction::Instruction},
     std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         path::{Path, PathBuf},
     },
 };
@@ -26,23 +26,11 @@ use {
 #[grammar = "sbpf.pest"]
 pub struct SbpfParser;
 
-/// Location of a label definition, including which file it was defined in.
-///
-/// The file identifier is the main source filename or a relative path to
-/// an included file (as written in the `.include` directive, normalized).
+/// A location in a source file — used both for label definitions and
+/// `.include` directive sites in the include chain.
 #[derive(Debug, Clone)]
-pub struct LabelLocation {
+pub struct SourceLocation {
     pub file: String,
-    pub span: std::ops::Range<usize>,
-}
-
-/// An `.include` directive site in some source file, used to build the
-/// include chain reported in diagnostics like `DuplicateLabel`.
-#[derive(Debug, Clone)]
-pub struct IncludeSite {
-    /// The file that contains the `.include` directive.
-    pub file: String,
-    /// The span of the `.include` directive inside `file`.
     pub span: std::ops::Range<usize>,
 }
 
@@ -50,7 +38,7 @@ pub struct IncludeSite {
 pub(crate) struct ParseContext<'a> {
     pub ast: &'a mut AST,
     pub const_map: &'a mut HashMap<String, Number>,
-    pub label_spans: &'a mut HashMap<String, LabelLocation>,
+    pub label_spans: &'a mut HashMap<String, SourceLocation>,
     pub errors: Vec<CompileError>,
     pub rodata_phase: bool,
     pub text_offset: u64,
@@ -61,25 +49,32 @@ pub(crate) struct ParseContext<'a> {
     /// into an included file (paths are resolved relative to the including
     /// file's directory).
     pub base_path: Option<PathBuf>,
+    /// The root base path (directory of the main source file). Used to
+    /// compute include identifiers relative to the project root so that
+    /// nested includes like `modules/a.s` including `b.s` register as
+    /// `modules/b.s` rather than just `b.s`.
+    pub root_base_path: Option<PathBuf>,
     /// File currently being parsed. For the main source this is the main
-    /// file name; for included files it is the relative path as written in
-    /// the `.include` directive (normalized).
+    /// file name; for included files it is the relative path from the
+    /// project root.
     pub current_file: String,
     /// Chain of `.include` sites leading to the currently-parsed source.
     /// Empty when parsing the main file. Used to annotate diagnostics with
     /// the point(s) where an included file was pulled in.
-    pub include_stack: Vec<IncludeSite>,
+    pub include_stack: Vec<SourceLocation>,
     /// Registry of all sources read so far: `file -> content`. Populated on
     /// each `.include`, plus the main file. Used by the build command to
     /// emit multi-file diagnostics.
     pub files: &'a mut HashMap<String, String>,
-    /// `(code_offset, file)` for each instruction emitted, in order.
-    /// Used to build multi-file line tables.
-    pub code_file_info: &'a mut Vec<(u64, String)>,
-    /// `(rodata_offset, file)` for each ROData node, in order.
-    pub rodata_file_info: &'a mut Vec<(u64, String)>,
-    /// Map from label name to the file where it was defined.
-    pub label_file_info: &'a mut HashMap<String, String>,
+    /// Canonicalized paths of files currently being parsed, used to detect
+    /// cyclic includes. A file is added before recursing and removed after.
+    pub include_set: HashSet<PathBuf>,
+}
+
+/// If the error has no file attribution yet, fill in the given file name
+/// so that errors originating from included files carry the correct attribution.
+pub(crate) fn attach_file_to_error(error: CompileError, file: &str) -> CompileError {
+    error.with_file(file)
 }
 
 /// BPF_X flag: Converts immediate variant opcodes to register variant opcodes
@@ -117,16 +112,6 @@ pub struct ParseResult {
     /// Registry of every source file read during parsing (main + includes).
     /// `file -> content`. Empty if `.include` was not used.
     pub sources: HashMap<String, String>,
-
-    /// `(code_offset, file)` for each instruction emitted, in order.
-    /// Used by the assembler to build multi-file debug line tables.
-    pub code_file_info: Vec<(u64, String)>,
-
-    /// `(rodata_offset, file)` for each ROData node, in order.
-    pub rodata_file_info: Vec<(u64, String)>,
-
-    /// Map from label name to the file it was defined in.
-    pub label_file_info: HashMap<String, String>,
 }
 
 /// Parse `source` as a standalone program. `.include` directives inside
@@ -157,11 +142,8 @@ pub fn parse_with_base_path(
 ) -> Result<ParseResult, Vec<CompileError>> {
     let mut ast = AST::new();
     let mut const_map = HashMap::<String, Number>::new();
-    let mut label_spans = HashMap::<String, LabelLocation>::new();
+    let mut label_spans = HashMap::<String, SourceLocation>::new();
     sources_out.insert(main_file_name.to_string(), source.to_string());
-    let mut code_file_info: Vec<(u64, String)> = Vec::new();
-    let mut rodata_file_info: Vec<(u64, String)> = Vec::new();
-    let mut label_file_info: HashMap<String, String> = HashMap::new();
 
     let (text_offset, rodata_offset, errors) = {
         let mut ctx = ParseContext {
@@ -174,12 +156,11 @@ pub fn parse_with_base_path(
             rodata_offset: 0,
             missing_text_directive: false,
             base_path: base_path.map(|p| p.to_path_buf()),
+            root_base_path: base_path.map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf())),
             current_file: main_file_name.to_string(),
             include_stack: Vec::new(),
             files: sources_out,
-            code_file_info: &mut code_file_info,
-            rodata_file_info: &mut rodata_file_info,
-            label_file_info: &mut label_file_info,
+            include_set: HashSet::new(),
         };
 
         process_source(source, &mut ctx);
@@ -196,9 +177,6 @@ pub fn parse_with_base_path(
 
     let mut result = ast.build_program(arch)?;
     result.sources = sources_out.clone();
-    result.code_file_info = code_file_info;
-    result.rodata_file_info = rodata_file_info;
-    result.label_file_info = label_file_info;
     Ok(result)
 }
 
@@ -209,9 +187,19 @@ pub(crate) fn process_source(source: &str, ctx: &mut ParseContext) {
     let pairs = match SbpfParser::parse(Rule::program, source) {
         Ok(p) => p,
         Err(e) => {
+            // Include the file name in the error so the user knows which
+            // file has the syntax problem — especially important for
+            // included files where the span is relative to that file's
+            // text, not the main source.
+            let error_msg = if ctx.include_stack.is_empty() {
+                e.to_string()
+            } else {
+                format!("in \"{}\": {}", ctx.current_file, e)
+            };
             ctx.errors.push(CompileError::ParseError {
-                error: e.to_string(),
+                error: error_msg,
                 span: 0..source.len(),
+                file: Some(ctx.current_file.clone()),
                 custom_label: None,
             });
             return;
@@ -251,16 +239,15 @@ fn process_statement(pair: Pair<Rule>, ctx: &mut ParseContext) {
                     Ok(instruction) => {
                         if !ctx.rodata_phase {
                             let size = instruction.get_size();
-                            ctx.code_file_info
-                                .push((ctx.text_offset, ctx.current_file.clone()));
                             ctx.ast.nodes.push(ASTNode::Instruction {
                                 instruction,
                                 offset: ctx.text_offset,
+                                file: Some(ctx.current_file.clone()),
                             });
                             ctx.text_offset += size;
                         }
                     }
-                    Err(e) => ctx.errors.push(e),
+                    Err(e) => ctx.errors.push(attach_file_to_error(e, &ctx.current_file)),
                 }
 
                 if ctx.rodata_phase && !ctx.missing_text_directive {
@@ -268,6 +255,7 @@ fn process_statement(pair: Pair<Rule>, ctx: &mut ParseContext) {
                     ctx.errors.push(CompileError::MissingTextDirective {
                         span: span_range,
                         custom_label: None,
+                        file: None,
                     });
                 }
             }
@@ -286,7 +274,7 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
         match item.as_rule() {
             Rule::identifier | Rule::numeric_label => match extract_label_from_pair(item) {
                 Ok(label) => label_opt = Some(label),
-                Err(e) => ctx.errors.push(e),
+                Err(e) => ctx.errors.push(attach_file_to_error(e, &ctx.current_file)),
             },
             Rule::directive_inner => {
                 directive_opt = Some(item);
@@ -315,18 +303,17 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
                         .collect(),
                 })),
                 custom_label: Some("Label already defined".to_string()),
+                file: Some(ctx.current_file.clone()),
             });
             return;
         }
         ctx.label_spans.insert(
             label_name.clone(),
-            LabelLocation {
+            SourceLocation {
                 file: ctx.current_file.clone(),
                 span: label_span.clone(),
             },
         );
-        ctx.label_file_info
-            .insert(label_name.clone(), ctx.current_file.clone());
 
         if ctx.rodata_phase {
             // Handle rodata label with directive
@@ -334,25 +321,25 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
                 match process_rodata_directive(label_name.clone(), label_span.clone(), dir_pair) {
                     Ok(rodata) => {
                         let size = rodata.get_size();
-                        ctx.rodata_file_info
-                            .push((ctx.rodata_offset, ctx.current_file.clone()));
                         ctx.ast.rodata_nodes.push(ASTNode::ROData {
                             rodata,
                             offset: ctx.rodata_offset,
+                            file: Some(ctx.current_file.clone()),
                         });
                         ctx.rodata_offset += size;
                     }
-                    Err(e) => ctx.errors.push(e),
+                    Err(e) => ctx.errors.push(attach_file_to_error(e, &ctx.current_file)),
                 }
             } else if let Some(inst_pair) = instruction_opt {
                 if let Err(e) = process_instruction(inst_pair, ctx.const_map, is_llvm) {
-                    ctx.errors.push(e);
+                    ctx.errors.push(attach_file_to_error(e, &ctx.current_file));
                 }
                 if !ctx.missing_text_directive {
                     ctx.missing_text_directive = true;
                     ctx.errors.push(CompileError::MissingTextDirective {
                         span: label_span,
                         custom_label: None,
+                        file: None,
                     });
                 }
             }
@@ -363,21 +350,21 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
                     span: label_span,
                 },
                 offset: ctx.text_offset,
+                file: Some(ctx.current_file.clone()),
             });
 
             if let Some(inst_pair) = instruction_opt {
                 match process_instruction(inst_pair, ctx.const_map, is_llvm) {
                     Ok(instruction) => {
                         let size = instruction.get_size();
-                        ctx.code_file_info
-                            .push((ctx.text_offset, ctx.current_file.clone()));
                         ctx.ast.nodes.push(ASTNode::Instruction {
                             instruction,
                             offset: ctx.text_offset,
+                            file: Some(ctx.current_file.clone()),
                         });
                         ctx.text_offset += size;
                     }
-                    Err(e) => ctx.errors.push(e),
+                    Err(e) => ctx.errors.push(attach_file_to_error(e, &ctx.current_file)),
                 }
             }
         }

--- a/crates/assembler/src/parser/mod.rs
+++ b/crates/assembler/src/parser/mod.rs
@@ -1,6 +1,6 @@
 pub mod common;
 mod default;
-mod directive;
+pub(crate) mod directive;
 mod llvm;
 
 use {
@@ -16,23 +16,70 @@ use {
     pest::{Parser, iterators::Pair},
     pest_derive::Parser,
     sbpf_common::{inst_param::Number, instruction::Instruction},
-    std::collections::HashMap,
+    std::{
+        collections::HashMap,
+        path::{Path, PathBuf},
+    },
 };
 
 #[derive(Parser)]
 #[grammar = "sbpf.pest"]
 pub struct SbpfParser;
 
-/// Context containing all mutable state during parsing
+/// Location of a label definition, including which file it was defined in.
+///
+/// The file identifier is the main source filename or a relative path to
+/// an included file (as written in the `.include` directive, normalized).
+#[derive(Debug, Clone)]
+pub struct LabelLocation {
+    pub file: String,
+    pub span: std::ops::Range<usize>,
+}
+
+/// An `.include` directive site in some source file, used to build the
+/// include chain reported in diagnostics like `DuplicateLabel`.
+#[derive(Debug, Clone)]
+pub struct IncludeSite {
+    /// The file that contains the `.include` directive.
+    pub file: String,
+    /// The span of the `.include` directive inside `file`.
+    pub span: std::ops::Range<usize>,
+}
+
+/// Context containing all mutable state during parsing.
 pub(crate) struct ParseContext<'a> {
     pub ast: &'a mut AST,
     pub const_map: &'a mut HashMap<String, Number>,
-    pub label_spans: &'a mut HashMap<String, std::ops::Range<usize>>,
+    pub label_spans: &'a mut HashMap<String, LabelLocation>,
     pub errors: Vec<CompileError>,
     pub rodata_phase: bool,
     pub text_offset: u64,
     pub rodata_offset: u64,
     pub missing_text_directive: bool,
+
+    /// Directory used to resolve `.include` paths. Updated when we descend
+    /// into an included file (paths are resolved relative to the including
+    /// file's directory).
+    pub base_path: Option<PathBuf>,
+    /// File currently being parsed. For the main source this is the main
+    /// file name; for included files it is the relative path as written in
+    /// the `.include` directive (normalized).
+    pub current_file: String,
+    /// Chain of `.include` sites leading to the currently-parsed source.
+    /// Empty when parsing the main file. Used to annotate diagnostics with
+    /// the point(s) where an included file was pulled in.
+    pub include_stack: Vec<IncludeSite>,
+    /// Registry of all sources read so far: `file -> content`. Populated on
+    /// each `.include`, plus the main file. Used by the build command to
+    /// emit multi-file diagnostics.
+    pub files: &'a mut HashMap<String, String>,
+    /// `(code_offset, file)` for each instruction emitted, in order.
+    /// Used to build multi-file line tables.
+    pub code_file_info: &'a mut Vec<(u64, String)>,
+    /// `(rodata_offset, file)` for each ROData node, in order.
+    pub rodata_file_info: &'a mut Vec<(u64, String)>,
+    /// Map from label name to the file where it was defined.
+    pub label_file_info: &'a mut HashMap<String, String>,
 }
 
 /// BPF_X flag: Converts immediate variant opcodes to register variant opcodes
@@ -66,20 +113,55 @@ pub struct ParseResult {
 
     // Debug sections we came across while byteparsing
     pub debug_sections: Vec<DebugSection>,
+
+    /// Registry of every source file read during parsing (main + includes).
+    /// `file -> content`. Empty if `.include` was not used.
+    pub sources: HashMap<String, String>,
+
+    /// `(code_offset, file)` for each instruction emitted, in order.
+    /// Used by the assembler to build multi-file debug line tables.
+    pub code_file_info: Vec<(u64, String)>,
+
+    /// `(rodata_offset, file)` for each ROData node, in order.
+    pub rodata_file_info: Vec<(u64, String)>,
+
+    /// Map from label name to the file it was defined in.
+    pub label_file_info: HashMap<String, String>,
 }
 
+/// Parse `source` as a standalone program. `.include` directives inside
+/// `source` will produce an error because no base path is available.
 pub fn parse(source: &str, arch: SbpfArch) -> Result<ParseResult, Vec<CompileError>> {
-    let pairs = SbpfParser::parse(Rule::program, source).map_err(|e| {
-        vec![CompileError::ParseError {
-            error: e.to_string(),
-            span: 0..source.len(),
-            custom_label: None,
-        }]
-    })?;
+    let mut sources_out = HashMap::new();
+    parse_with_base_path(source, arch, None, "source", &mut sources_out)
+}
 
+/// Parse `source` with support for `.include` directives.
+///
+/// `base_path` is the directory used to resolve `.include "<path>"` lines
+/// in the main source. `main_file_name` is the identifier that will be
+/// used for the main file in diagnostics and debug info (typically the
+/// file name without the directory).
+///
+/// `sources_out` is populated with every source read during parsing — the
+/// main file plus any files pulled in via `.include` — keyed by the file
+/// identifier used in diagnostics. It is populated in both the success
+/// and failure paths, so callers can emit multi-file diagnostics even
+/// when assembly fails (e.g. `DuplicateLabel` across includes).
+pub fn parse_with_base_path(
+    source: &str,
+    arch: SbpfArch,
+    base_path: Option<&Path>,
+    main_file_name: &str,
+    sources_out: &mut HashMap<String, String>,
+) -> Result<ParseResult, Vec<CompileError>> {
     let mut ast = AST::new();
     let mut const_map = HashMap::<String, Number>::new();
-    let mut label_spans = HashMap::<String, std::ops::Range<usize>>::new();
+    let mut label_spans = HashMap::<String, LabelLocation>::new();
+    sources_out.insert(main_file_name.to_string(), source.to_string());
+    let mut code_file_info: Vec<(u64, String)> = Vec::new();
+    let mut rodata_file_info: Vec<(u64, String)> = Vec::new();
+    let mut label_file_info: HashMap<String, String> = HashMap::new();
 
     let (text_offset, rodata_offset, errors) = {
         let mut ctx = ParseContext {
@@ -91,21 +173,16 @@ pub fn parse(source: &str, arch: SbpfArch) -> Result<ParseResult, Vec<CompileErr
             text_offset: 0,
             rodata_offset: 0,
             missing_text_directive: false,
+            base_path: base_path.map(|p| p.to_path_buf()),
+            current_file: main_file_name.to_string(),
+            include_stack: Vec::new(),
+            files: sources_out,
+            code_file_info: &mut code_file_info,
+            rodata_file_info: &mut rodata_file_info,
+            label_file_info: &mut label_file_info,
         };
 
-        for pair in pairs {
-            match pair.as_rule() {
-                Rule::program_default | Rule::program_llvm => {
-                    for statement in pair.into_inner() {
-                        if statement.as_rule() == Rule::EOI {
-                            continue;
-                        }
-                        process_statement(statement, &mut ctx);
-                    }
-                }
-                _ => {}
-            }
-        }
+        process_source(source, &mut ctx);
 
         (ctx.text_offset, ctx.rodata_offset, ctx.errors)
     };
@@ -117,7 +194,43 @@ pub fn parse(source: &str, arch: SbpfArch) -> Result<ParseResult, Vec<CompileErr
     ast.set_text_size(text_offset);
     ast.set_rodata_size(rodata_offset);
 
-    ast.build_program(arch)
+    let mut result = ast.build_program(arch)?;
+    result.sources = sources_out.clone();
+    result.code_file_info = code_file_info;
+    result.rodata_file_info = rodata_file_info;
+    result.label_file_info = label_file_info;
+    Ok(result)
+}
+
+/// Parse `source` into `ctx`. Used both for the main file and recursively
+/// for included files. Spans in this source are relative to the source
+/// string; `ctx.current_file` identifies which file they belong to.
+pub(crate) fn process_source(source: &str, ctx: &mut ParseContext) {
+    let pairs = match SbpfParser::parse(Rule::program, source) {
+        Ok(p) => p,
+        Err(e) => {
+            ctx.errors.push(CompileError::ParseError {
+                error: e.to_string(),
+                span: 0..source.len(),
+                custom_label: None,
+            });
+            return;
+        }
+    };
+
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::program_default | Rule::program_llvm => {
+                for statement in pair.into_inner() {
+                    if statement.as_rule() == Rule::EOI {
+                        continue;
+                    }
+                    process_statement(statement, ctx);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 fn process_statement(pair: Pair<Rule>, ctx: &mut ParseContext) {
@@ -138,6 +251,8 @@ fn process_statement(pair: Pair<Rule>, ctx: &mut ParseContext) {
                     Ok(instruction) => {
                         if !ctx.rodata_phase {
                             let size = instruction.get_size();
+                            ctx.code_file_info
+                                .push((ctx.text_offset, ctx.current_file.clone()));
                             ctx.ast.nodes.push(ASTNode::Instruction {
                                 instruction,
                                 offset: ctx.text_offset,
@@ -185,17 +300,33 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
 
     if let Some((label_name, label_span)) = label_opt {
         // Check for duplicate labels
-        if let Some(original_span) = ctx.label_spans.get(&label_name) {
+        if let Some(original) = ctx.label_spans.get(&label_name) {
             ctx.errors.push(CompileError::DuplicateLabel {
                 label: label_name,
                 span: label_span,
-                original_span: original_span.clone(),
+                original_span: original.span.clone(),
+                multi: Some(Box::new(crate::errors::DuplicateLabelMulti {
+                    span_file: ctx.current_file.clone(),
+                    original_span_file: original.file.clone(),
+                    include_chain: ctx
+                        .include_stack
+                        .iter()
+                        .map(|s| (s.file.clone(), s.span.clone()))
+                        .collect(),
+                })),
                 custom_label: Some("Label already defined".to_string()),
             });
             return;
         }
-        ctx.label_spans
-            .insert(label_name.clone(), label_span.clone());
+        ctx.label_spans.insert(
+            label_name.clone(),
+            LabelLocation {
+                file: ctx.current_file.clone(),
+                span: label_span.clone(),
+            },
+        );
+        ctx.label_file_info
+            .insert(label_name.clone(), ctx.current_file.clone());
 
         if ctx.rodata_phase {
             // Handle rodata label with directive
@@ -203,6 +334,8 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
                 match process_rodata_directive(label_name.clone(), label_span.clone(), dir_pair) {
                     Ok(rodata) => {
                         let size = rodata.get_size();
+                        ctx.rodata_file_info
+                            .push((ctx.rodata_offset, ctx.current_file.clone()));
                         ctx.ast.rodata_nodes.push(ASTNode::ROData {
                             rodata,
                             offset: ctx.rodata_offset,
@@ -236,6 +369,8 @@ fn process_label(pair: Pair<Rule>, ctx: &mut ParseContext) {
                 match process_instruction(inst_pair, ctx.const_map, is_llvm) {
                     Ok(instruction) => {
                         let size = instruction.get_size();
+                        ctx.code_file_info
+                            .push((ctx.text_offset, ctx.current_file.clone()));
                         ctx.ast.nodes.push(ASTNode::Instruction {
                             instruction,
                             offset: ctx.text_offset,

--- a/crates/assembler/src/program.rs
+++ b/crates/assembler/src/program.rs
@@ -29,13 +29,10 @@ impl Program {
             prog_is_static,
             arch,
             debug_sections,
-            // The following fields are consumed by the assembler before
-            // reaching here (e.g. to build multi-file debug data); they are
-            // not needed for bytecode emission.
+            // Consumed by the assembler before reaching here (e.g. to
+            // build multi-file debug data); not needed for bytecode
+            // emission.
             sources: _,
-            code_file_info: _,
-            rodata_file_info: _,
-            label_file_info: _,
         }: ParseResult,
         debug_data: Option<DebugData>,
     ) -> Self {

--- a/crates/assembler/src/program.rs
+++ b/crates/assembler/src/program.rs
@@ -29,6 +29,13 @@ impl Program {
             prog_is_static,
             arch,
             debug_sections,
+            // The following fields are consumed by the assembler before
+            // reaching here (e.g. to build multi-file debug data); they are
+            // not needed for bytecode emission.
+            sources: _,
+            code_file_info: _,
+            rodata_file_info: _,
+            label_file_info: _,
         }: ParseResult,
         debug_data: Option<DebugData>,
     ) -> Self {
@@ -550,6 +557,8 @@ mod tests {
             directory: "/test".to_string(),
             lines: vec![],
             labels: vec![],
+            lines_multi: Vec::new(),
+            labels_multi: Vec::new(),
             code_start: 0,
             code_end: 8,
         });

--- a/crates/assembler/src/sbpf.pest
+++ b/crates/assembler/src/sbpf.pest
@@ -67,6 +67,9 @@ directive_section = {
   | ".rodata"
 }
 
+// Include another file inline
+directive_include = { ".include" ~ string_literal }
+
 // Data directives
 directive_ascii = { ".ascii" ~ string_literal }
 directive_byte  = { ".byte" ~ number ~ ("," ~ number)* }
@@ -81,6 +84,7 @@ directive_inner = {
   | directive_extern
   | directive_equ
   | directive_section
+  | directive_include
   | directive_ascii
   | directive_byte
   | directive_short

--- a/crates/assembler/src/section.rs
+++ b/crates/assembler/src/section.rs
@@ -131,6 +131,7 @@ impl DataSection {
             if let ASTNode::ROData {
                 rodata: ROData { name, args, .. },
                 offset,
+                ..
             } = node
                 && let Some(Token::StringLiteral(str_literal, _)) = args.get(1)
             {
@@ -875,6 +876,7 @@ mod tests {
         let nodes = vec![ASTNode::Instruction {
             instruction: inst,
             offset: 0,
+            file: None,
         }];
 
         let section = CodeSection::new(nodes, 8);
@@ -895,6 +897,7 @@ mod tests {
         let nodes = vec![ASTNode::Instruction {
             instruction: inst,
             offset: 0,
+            file: None,
         }];
 
         let section = CodeSection::new(nodes, 8);
@@ -912,7 +915,11 @@ mod tests {
             ],
             span: 0..10,
         };
-        let nodes = vec![ASTNode::ROData { rodata, offset: 0 }];
+        let nodes = vec![ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        }];
 
         let section = DataSection::new(nodes, 2);
         assert_eq!(section.name(), ".rodata");
@@ -929,7 +936,11 @@ mod tests {
             ],
             span: 0..12,
         };
-        let nodes = vec![ASTNode::ROData { rodata, offset: 0 }];
+        let nodes = vec![ASTNode::ROData {
+            rodata,
+            offset: 0,
+            file: None,
+        }];
 
         let section = DataSection::new(nodes, 4);
         let rodata = section.rodata();
@@ -1041,6 +1052,7 @@ mod tests {
             vec![ASTNode::Instruction {
                 instruction: inst,
                 offset: 0,
+                file: None,
             }],
             8,
         );

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -3,13 +3,13 @@ use {
     clap::{Args, ValueEnum},
     codespan_reporting::{
         diagnostic::{Diagnostic, Label},
-        files::SimpleFile,
+        files::SimpleFiles,
         term,
     },
     ed25519_dalek::SigningKey,
     rand::rngs::OsRng,
     sbpf_assembler::{Assembler, AssemblerOption, DebugMode, SbpfArch, errors::CompileError},
-    std::{fs, fs::create_dir_all, path::Path, time::Instant},
+    std::{collections::HashMap, fs, fs::create_dir_all, path::Path, time::Instant},
     termcolor::{ColorChoice, StandardStream},
 };
 
@@ -44,30 +44,77 @@ impl From<ArchArg> for SbpfArch {
     }
 }
 
+/// Convert a [`CompileError`] into a [`codespan_reporting`] diagnostic.
+///
+/// The `resolve` closure maps a file identifier (as used by the parser —
+/// either the main file name or a relative `.include` path) to a
+/// [`SimpleFiles`] file id. For errors without explicit file info the
+/// `default_file_id` is used.
+///
+/// Multi-file support: for [`CompileError::DuplicateLabel`] produced by
+/// a multi-file parse (`assemble_with_base_path`), the error carries the
+/// file for both the original and the duplicate definition, plus the
+/// chain of `.include` directives that led to the duplicate. Each of
+/// those becomes a label in the emitted diagnostic so the user sees:
+///
+/// * primary — the redefinition, in its own file
+/// * secondary — the original definition, in its own file
+/// * secondary — one per `.include` site in the chain ("included from
+///   here"), annotating every `.include` directive that pulled in the
+///   file containing the duplicate
 pub trait AsDiagnostic {
-    // currently only support single source file reporting
-    fn to_diagnostic(&self) -> Diagnostic<()>;
+    fn to_diagnostic<F>(&self, default_file_id: usize, resolve: F) -> Diagnostic<usize>
+    where
+        F: Fn(&str) -> usize;
 }
 
 impl AsDiagnostic for CompileError {
-    fn to_diagnostic(&self) -> Diagnostic<()> {
+    fn to_diagnostic<F>(&self, default_file_id: usize, resolve: F) -> Diagnostic<usize>
+    where
+        F: Fn(&str) -> usize,
+    {
         match self {
-            // Show both the redefinition and the original definition
             CompileError::DuplicateLabel {
                 span,
                 original_span,
+                multi,
                 ..
-            } => Diagnostic::error()
-                .with_message(self.to_string())
-                .with_labels(vec![
-                    Label::primary((), span.start..span.end).with_message(self.label()),
-                    Label::secondary((), original_span.start..original_span.end)
+            } => {
+                // Resolve the file ids for the two definitions. In
+                // single-file mode (no `.include`), both fall back to
+                // `default_file_id`. In multi-file mode, the parser
+                // populates `multi` with the actual file names.
+                let (span_id, original_id) = if let Some(m) = multi.as_deref() {
+                    (resolve(&m.span_file), resolve(&m.original_span_file))
+                } else {
+                    (default_file_id, default_file_id)
+                };
+                let mut labels = vec![
+                    Label::primary(span_id, span.start..span.end).with_message(self.label()),
+                    Label::secondary(original_id, original_span.start..original_span.end)
                         .with_message("previous definition is here"),
-                ]),
+                ];
+                // When the duplicate originates inside an included file,
+                // annotate every `.include` directive in the chain so
+                // the user can trace where the second definition came
+                // from.
+                if let Some(m) = multi.as_deref() {
+                    for (include_file, include_span) in &m.include_chain {
+                        let file_id = resolve(include_file);
+                        labels.push(
+                            Label::secondary(file_id, include_span.start..include_span.end)
+                                .with_message("included from here"),
+                        );
+                    }
+                }
+                Diagnostic::error()
+                    .with_message(self.to_string())
+                    .with_labels(labels)
+            }
             _ => Diagnostic::error()
                 .with_message(self.to_string())
                 .with_labels(vec![
-                    Label::primary((), self.span().start..self.span().end)
+                    Label::primary(default_file_id, self.span().start..self.span().end)
                         .with_message(self.label()),
                 ]),
         }
@@ -84,21 +131,25 @@ pub fn build(args: BuildArgs) -> Result<()> {
     // Function to compile assembly
     fn compile_assembly(src: &str, deploy: &str, debug: bool, arch: SbpfArch) -> Result<()> {
         let source_code = std::fs::read_to_string(src).unwrap();
-        let file = SimpleFile::new(src.to_string(), source_code.clone());
+
+        let main_file_name = Path::new(src)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown.s")
+            .to_string();
+        let base_path_buf = Path::new(src)
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| Path::new(".").to_path_buf());
+        let canonical_base = base_path_buf
+            .canonicalize()
+            .unwrap_or_else(|_| base_path_buf.clone());
 
         // Build assembler options
         let debug_mode = if debug {
-            let filename = Path::new(src)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown.s");
-            let directory = Path::new(src)
-                .parent()
-                .and_then(|p| p.canonicalize().ok())
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|| ".".to_string());
+            let directory = canonical_base.to_string_lossy().to_string();
             Some(DebugMode {
-                filename: filename.to_string(),
+                filename: main_file_name.clone(),
                 directory,
             })
         } else {
@@ -108,16 +159,46 @@ pub fn build(args: BuildArgs) -> Result<()> {
         let options = AssemblerOption { arch, debug_mode };
 
         let assembler = Assembler::new(options);
-        let result = assembler.assemble(&source_code);
+        let result = assembler.assemble_with_base_path(
+            &main_file_name,
+            &source_code,
+            canonical_base.as_path(),
+        );
 
-        let bytecode = match result {
+        // Build a SimpleFiles registry mirroring the parser's view so
+        // diagnostic labels can refer to the correct source file (main
+        // or any `.include`-d file). The main file is always added first
+        // and its id is used as the default for errors without explicit
+        // file info.
+        let mut files = SimpleFiles::new();
+        let mut file_ids: HashMap<String, usize> = HashMap::new();
+        // Ensure the main file is inserted even if parsing bailed before
+        // reading it (shouldn't happen — the assembler always registers
+        // main — but is a defensive fallback).
+        let main_content = result
+            .sources
+            .get(&main_file_name)
+            .cloned()
+            .unwrap_or_else(|| source_code.clone());
+        let main_file_id = files.add(main_file_name.clone(), main_content);
+        file_ids.insert(main_file_name.clone(), main_file_id);
+        for (name, content) in &result.sources {
+            if name == &main_file_name {
+                continue;
+            }
+            let id = files.add(name.clone(), content.clone());
+            file_ids.insert(name.clone(), id);
+        }
+        let resolve = |file: &str| -> usize { *file_ids.get(file).unwrap_or(&main_file_id) };
+
+        let bytecode = match result.bytecode {
             Ok(bytecode) => bytecode,
             Err(errors) => {
                 for error in errors {
                     let writer = StandardStream::stderr(ColorChoice::Auto);
                     let config = term::Config::default();
-                    let diagnostic = error.to_diagnostic();
-                    term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;
+                    let diagnostic = error.to_diagnostic(main_file_id, resolve);
+                    term::emit(&mut writer.lock(), &config, &files, &diagnostic)?;
                 }
                 return Err(Error::msg("Compilation failed"));
             }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -9,7 +9,12 @@ use {
     ed25519_dalek::SigningKey,
     rand::rngs::OsRng,
     sbpf_assembler::{Assembler, AssemblerOption, DebugMode, SbpfArch, errors::CompileError},
-    std::{collections::HashMap, fs, fs::create_dir_all, path::Path, time::Instant},
+    std::{
+        collections::HashMap,
+        fs::{self, create_dir_all},
+        path::Path,
+        time::Instant,
+    },
     termcolor::{ColorChoice, StandardStream},
 };
 
@@ -111,12 +116,18 @@ impl AsDiagnostic for CompileError {
                     .with_message(self.to_string())
                     .with_labels(labels)
             }
-            _ => Diagnostic::error()
-                .with_message(self.to_string())
-                .with_labels(vec![
-                    Label::primary(default_file_id, self.span().start..self.span().end)
-                        .with_message(self.label()),
-                ]),
+            _ => {
+                let file_id = match self.file() {
+                    Some(f) => resolve(f),
+                    None => default_file_id,
+                };
+                Diagnostic::error()
+                    .with_message(self.to_string())
+                    .with_labels(vec![
+                        Label::primary(file_id, self.span().start..self.span().end)
+                            .with_message(self.label()),
+                    ])
+            }
         }
     }
 }
@@ -137,17 +148,17 @@ pub fn build(args: BuildArgs) -> Result<()> {
             .and_then(|n| n.to_str())
             .unwrap_or("unknown.s")
             .to_string();
-        let base_path_buf = Path::new(src)
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| Path::new(".").to_path_buf());
-        let canonical_base = base_path_buf
-            .canonicalize()
-            .unwrap_or_else(|_| base_path_buf.clone());
+        let base_path_buf = {
+            let p = Path::new(src)
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| Path::new(".").to_path_buf());
+            p.canonicalize().unwrap_or(p)
+        };
 
         // Build assembler options
         let debug_mode = if debug {
-            let directory = canonical_base.to_string_lossy().to_string();
+            let directory = base_path_buf.to_string_lossy().to_string();
             Some(DebugMode {
                 filename: main_file_name.clone(),
                 directory,
@@ -162,38 +173,33 @@ pub fn build(args: BuildArgs) -> Result<()> {
         let result = assembler.assemble_with_base_path(
             &main_file_name,
             &source_code,
-            canonical_base.as_path(),
+            base_path_buf.as_path(),
         );
-
-        // Build a SimpleFiles registry mirroring the parser's view so
-        // diagnostic labels can refer to the correct source file (main
-        // or any `.include`-d file). The main file is always added first
-        // and its id is used as the default for errors without explicit
-        // file info.
-        let mut files = SimpleFiles::new();
-        let mut file_ids: HashMap<String, usize> = HashMap::new();
-        // Ensure the main file is inserted even if parsing bailed before
-        // reading it (shouldn't happen — the assembler always registers
-        // main — but is a defensive fallback).
-        let main_content = result
-            .sources
-            .get(&main_file_name)
-            .cloned()
-            .unwrap_or_else(|| source_code.clone());
-        let main_file_id = files.add(main_file_name.clone(), main_content);
-        file_ids.insert(main_file_name.clone(), main_file_id);
-        for (name, content) in &result.sources {
-            if name == &main_file_name {
-                continue;
-            }
-            let id = files.add(name.clone(), content.clone());
-            file_ids.insert(name.clone(), id);
-        }
-        let resolve = |file: &str| -> usize { *file_ids.get(file).unwrap_or(&main_file_id) };
 
         let bytecode = match result.bytecode {
             Ok(bytecode) => bytecode,
             Err(errors) => {
+                // Build a SimpleFiles registry only when there is an
+                // error — this is the only code path that needs it.
+                let mut files = SimpleFiles::new();
+                let mut file_ids: HashMap<String, usize> = HashMap::new();
+                let main_content = result
+                    .sources
+                    .get(&main_file_name)
+                    .cloned()
+                    .unwrap_or_else(|| source_code.clone());
+                let main_file_id = files.add(main_file_name.clone(), main_content);
+                file_ids.insert(main_file_name.clone(), main_file_id);
+                for (name, content) in &result.sources {
+                    if name == &main_file_name {
+                        continue;
+                    }
+                    let id = files.add(name.clone(), content.clone());
+                    file_ids.insert(name.clone(), id);
+                }
+                let resolve =
+                    |file: &str| -> usize { *file_ids.get(file).unwrap_or(&main_file_id) };
+
                 for error in errors {
                     let writer = StandardStream::stderr(ColorChoice::Auto);
                     let config = term::Config::default();

--- a/tests/test_include.rs
+++ b/tests/test_include.rs
@@ -530,3 +530,60 @@ entrypoint:
 
     env.cleanup();
 }
+
+/// Cyclic includes (A includes B, B includes A) should produce a clear
+/// error instead of infinite recursion / stack overflow.
+#[test]
+fn test_include_cyclic_detection() {
+    let env = TestEnv::new("include_cyclic");
+
+    init_project(&env, "include_cyclic");
+    verify_project_structure(&env, "include_cyclic");
+
+    write_include_file(
+        &env,
+        "include_cyclic",
+        "a.s",
+        r#".include "b.s"
+"#,
+    );
+
+    write_include_file(
+        &env,
+        "include_cyclic",
+        "b.s",
+        r#".include "a.s"
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_cyclic",
+        r#".globl entrypoint
+.include "a.s"
+.text
+entrypoint:
+    exit
+"#,
+    );
+
+    let output = Command::new(&env.sbpf_bin)
+        .current_dir(&env.project_dir)
+        .arg("build")
+        .output()
+        .expect("Failed to run sbpf build");
+
+    assert!(
+        !output.status.success(),
+        "Build should fail on cyclic include"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Cyclic include") || stderr.contains("cyclic include"),
+        "Error should mention cyclic include: {}",
+        stderr
+    );
+
+    env.cleanup();
+}

--- a/tests/test_include.rs
+++ b/tests/test_include.rs
@@ -1,0 +1,532 @@
+//! Integration tests for the `.include` directive.
+//!
+//! These tests exercise the end-to-end build path — they invoke the
+//! `sbpf` binary against a real project on disk and check that the
+//! resulting `.so` files (or error messages) match expectations.
+//!
+//! The `.include` directive is implemented inside the assembler parser
+//! (not as a text-level preprocessor in `build.rs`). `.include "path"`
+//! reads the referenced file and parses it into the same AST, so
+//! labels are shared, duplicates are caught by the normal
+//! `DuplicateLabel` check, and DWARF debug info tracks the source file
+//! each instruction came from.
+//!
+//! Contract covered:
+//!
+//! * Basic `.include` works and produces a working program.
+//! * Nested `.include` (included file includes another file) works.
+//! * `.globl`/`.global` are allowed in included files.
+//! * Paths are resolved relative to the *including* file, not the
+//!   main file.
+//! * A missing include path produces a readable error.
+//! * Duplicate labels across files produce a `DuplicateLabel` error
+//!   that names both files and points at the main-file `.include`
+//!   directive that pulled in the second definition.
+//! * When the duplicate is inside the main file, no `.include` chain is
+//!   reported.
+
+mod utils;
+
+use {
+    std::process::Command,
+    utils::{
+        TestEnv, init_project, run_build, update_assembly_file, verify_project_structure,
+        verify_so_files, write_include_file,
+    },
+};
+
+/// Main file that includes a helper and calls into it.
+///
+/// The helper file defines a `.rodata` entry and a code routine. Labels
+/// are unique across files so this builds without any prefixing.
+#[test]
+fn test_include_directive() {
+    let env = TestEnv::new("include_basic");
+
+    init_project(&env, "include_basic");
+    verify_project_structure(&env, "include_basic");
+
+    write_include_file(
+        &env,
+        "include_basic",
+        "log.s",
+        r#".text
+custom_log:
+    lddw r1, include_msg
+    lddw r2, 9
+    call sol_log_
+    exit
+
+.rodata
+    include_msg: .ascii "from log."
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_basic",
+        r#".globl entrypoint
+.include "log.s"
+.text
+entrypoint:
+    call custom_log
+    mov64 r0, 0
+    exit
+"#,
+    );
+
+    run_build(&env);
+    verify_so_files(&env);
+
+    env.cleanup();
+}
+
+/// Nested include: main → layer1.s → layer2.s. Proves that `.include`
+/// paths inside an included file are resolved relative to that file's
+/// own directory, not the main file's.
+#[test]
+fn test_include_nested() {
+    let env = TestEnv::new("include_nested");
+
+    init_project(&env, "include_nested");
+    verify_project_structure(&env, "include_nested");
+
+    write_include_file(
+        &env,
+        "include_nested",
+        "layer2.s",
+        r#".text
+deep_log:
+    lddw r1, deep_msg
+    lddw r2, 10
+    call sol_log_
+    exit
+
+.rodata
+    deep_msg: .ascii "deep call."
+"#,
+    );
+
+    write_include_file(
+        &env,
+        "include_nested",
+        "layer1.s",
+        r#".include "layer2.s"
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_nested",
+        r#".globl entrypoint
+.include "layer1.s"
+.text
+entrypoint:
+    call deep_log
+    mov64 r0, 0
+    exit
+"#,
+    );
+
+    run_build(&env);
+    verify_so_files(&env);
+
+    env.cleanup();
+}
+
+/// Paths inside a nested include are resolved relative to the including
+/// file. Here `modules/a.s` includes `b.s`, which lives alongside it in
+/// `modules/` — not in the main directory.
+#[test]
+fn test_include_nested_resolves_relative_to_including_file() {
+    let env = TestEnv::new("include_rel_path");
+
+    init_project(&env, "include_rel_path");
+    verify_project_structure(&env, "include_rel_path");
+
+    write_include_file(
+        &env,
+        "include_rel_path",
+        "modules/b.s",
+        r#".text
+b_func:
+    lddw r1, b_msg
+    lddw r2, 6
+    call sol_log_
+    exit
+
+.rodata
+    b_msg: .ascii "from b"
+"#,
+    );
+
+    write_include_file(
+        &env,
+        "include_rel_path",
+        "modules/a.s",
+        r#".include "b.s"
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_rel_path",
+        r#".globl entrypoint
+.include "modules/a.s"
+.text
+entrypoint:
+    call b_func
+    mov64 r0, 0
+    exit
+"#,
+    );
+
+    run_build(&env);
+    verify_so_files(&env);
+
+    env.cleanup();
+}
+
+/// `.globl` and `.global` are allowed anywhere, including inside
+/// included files. This is per the agreed direction that `.include`
+/// is pure textual inclusion, not import semantics.
+#[test]
+fn test_include_allows_globl_in_included_file() {
+    let env = TestEnv::new("include_globl");
+
+    init_project(&env, "include_globl");
+    verify_project_structure(&env, "include_globl");
+
+    write_include_file(
+        &env,
+        "include_globl",
+        "log.s",
+        r#".global custom_log
+.text
+custom_log:
+    lddw r1, include_msg
+    lddw r2, 9
+    call sol_log_
+    exit
+
+.rodata
+    include_msg: .ascii "from log."
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_globl",
+        r#".globl entrypoint
+.include "log.s"
+.text
+entrypoint:
+    call custom_log
+    mov64 r0, 0
+    exit
+"#,
+    );
+
+    run_build(&env);
+    verify_so_files(&env);
+
+    env.cleanup();
+}
+
+/// A missing include path produces a clear error message naming the
+/// missing file.
+#[test]
+fn test_include_missing_file_fails() {
+    let env = TestEnv::new("include_missing");
+
+    init_project(&env, "include_missing");
+    verify_project_structure(&env, "include_missing");
+
+    update_assembly_file(
+        &env,
+        "include_missing",
+        r#".globl entrypoint
+.include "nonexistent.s"
+.text
+entrypoint:
+    exit
+"#,
+    );
+
+    let output = Command::new(&env.sbpf_bin)
+        .current_dir(&env.project_dir)
+        .arg("build")
+        .output()
+        .expect("Failed to run sbpf build");
+
+    assert!(
+        !output.status.success(),
+        "Build should fail when include target is missing"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nonexistent.s"),
+        "Error should mention the missing file: {}",
+        stderr
+    );
+
+    env.cleanup();
+}
+
+/// A label defined in both the main file and an included file produces
+/// a `DuplicateLabel` error. The error output should show both the
+/// original (main file) and the redefinition (included file), and
+/// should point at the `.include` directive that pulled in the second
+/// definition.
+#[test]
+fn test_include_duplicate_label_main_then_included() {
+    let env = TestEnv::new("include_dup_main_inc");
+
+    init_project(&env, "include_dup_main_inc");
+    verify_project_structure(&env, "include_dup_main_inc");
+
+    write_include_file(
+        &env,
+        "include_dup_main_inc",
+        "log.s",
+        r#".text
+shared:
+    exit
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_dup_main_inc",
+        r#".globl entrypoint
+.text
+shared:
+    mov64 r0, 1
+    exit
+.include "log.s"
+entrypoint:
+    call shared
+    exit
+"#,
+    );
+
+    let output = Command::new(&env.sbpf_bin)
+        .current_dir(&env.project_dir)
+        .arg("build")
+        .output()
+        .expect("Failed to run sbpf build");
+
+    assert!(
+        !output.status.success(),
+        "Build should fail on duplicate label across main + included file"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Duplicate label") && stderr.contains("shared"),
+        "Error should mention DuplicateLabel for 'shared': {}",
+        stderr
+    );
+    // Both files should be referenced somewhere in the rendered output.
+    assert!(
+        stderr.contains("log.s"),
+        "Error output should reference the included file 'log.s': {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("included from here"),
+        "Error output should point at the .include directive: {}",
+        stderr
+    );
+
+    env.cleanup();
+}
+
+/// Two included files each define the same label. The resulting error
+/// should reference both files and show the `.include` directive chain.
+#[test]
+fn test_include_duplicate_label_between_two_includes() {
+    let env = TestEnv::new("include_dup_two_inc");
+
+    init_project(&env, "include_dup_two_inc");
+    verify_project_structure(&env, "include_dup_two_inc");
+
+    write_include_file(
+        &env,
+        "include_dup_two_inc",
+        "first.s",
+        r#".text
+helper:
+    mov64 r0, 1
+    exit
+"#,
+    );
+
+    write_include_file(
+        &env,
+        "include_dup_two_inc",
+        "second.s",
+        r#".text
+helper:
+    mov64 r0, 2
+    exit
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_dup_two_inc",
+        r#".globl entrypoint
+.include "first.s"
+.include "second.s"
+entrypoint:
+    call helper
+    exit
+"#,
+    );
+
+    let output = Command::new(&env.sbpf_bin)
+        .current_dir(&env.project_dir)
+        .arg("build")
+        .output()
+        .expect("Failed to run sbpf build");
+
+    assert!(
+        !output.status.success(),
+        "Build should fail on duplicate label between two included files"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Duplicate label") && stderr.contains("helper"),
+        "Error should mention DuplicateLabel for 'helper': {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("first.s") && stderr.contains("second.s"),
+        "Error output should reference both included files: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("included from here"),
+        "Error output should point at the .include directive for the second file: {}",
+        stderr
+    );
+
+    env.cleanup();
+}
+
+/// A duplicate label inside a single file still works as before — no
+/// include chain is reported and the error only references the main
+/// file.
+#[test]
+fn test_include_duplicate_label_same_file_no_chain() {
+    let env = TestEnv::new("include_dup_same");
+
+    init_project(&env, "include_dup_same");
+    verify_project_structure(&env, "include_dup_same");
+
+    update_assembly_file(
+        &env,
+        "include_dup_same",
+        r#".globl entrypoint
+entrypoint:
+    mov64 r0, 1
+entrypoint:
+    exit
+"#,
+    );
+
+    let output = Command::new(&env.sbpf_bin)
+        .current_dir(&env.project_dir)
+        .arg("build")
+        .output()
+        .expect("Failed to run sbpf build");
+
+    assert!(
+        !output.status.success(),
+        "Build should fail on duplicate label in the same file"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Duplicate label") && stderr.contains("entrypoint"),
+        "Error should mention DuplicateLabel for 'entrypoint': {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("included from here"),
+        "Same-file duplicates should not report an include chain: {}",
+        stderr
+    );
+
+    env.cleanup();
+}
+
+/// Duplicate `.rodata` labels across files are detected the same way
+/// as code labels. Regression for the old "prefix data labels"
+/// behaviour: there should be no implicit renaming, just a normal
+/// duplicate error.
+#[test]
+fn test_include_duplicate_rodata_label() {
+    let env = TestEnv::new("include_dup_rodata");
+
+    init_project(&env, "include_dup_rodata");
+    verify_project_structure(&env, "include_dup_rodata");
+
+    write_include_file(
+        &env,
+        "include_dup_rodata",
+        "a.s",
+        r#".rodata
+    msg: .ascii "from a"
+"#,
+    );
+
+    write_include_file(
+        &env,
+        "include_dup_rodata",
+        "b.s",
+        r#".rodata
+    msg: .ascii "from b"
+"#,
+    );
+
+    update_assembly_file(
+        &env,
+        "include_dup_rodata",
+        r#".globl entrypoint
+.include "a.s"
+.include "b.s"
+.text
+entrypoint:
+    exit
+"#,
+    );
+
+    let output = Command::new(&env.sbpf_bin)
+        .current_dir(&env.project_dir)
+        .arg("build")
+        .output()
+        .expect("Failed to run sbpf build");
+
+    assert!(
+        !output.status.success(),
+        "Build should fail on duplicate rodata label across includes"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Duplicate label") && stderr.contains("msg"),
+        "Error should mention duplicate rodata label 'msg': {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("a.s") && stderr.contains("b.s"),
+        "Error should reference both include files: {}",
+        stderr
+    );
+
+    env.cleanup();
+}

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -230,3 +230,22 @@ pub fn update_assembly_file(env: &TestEnv, project_name: &str, content: &str) {
         .unwrap_or_else(|_| panic!("Failed to write new {}.s content", project_name));
     println!("✅ Updated {}.s with specified content", project_name);
 }
+
+/// Write an extra assembly file next to the main program file so it can
+/// be referenced via `.include`. `relative_path` is resolved relative to
+/// `src/<project_name>/` and may contain subdirectories, which will be
+/// created if needed.
+#[allow(dead_code)]
+pub fn write_include_file(env: &TestEnv, project_name: &str, relative_path: &str, content: &str) {
+    let file_path = env
+        .project_dir
+        .join(format!("src/{}", project_name))
+        .join(relative_path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent)
+            .unwrap_or_else(|_| panic!("Failed to create parent directory for {:?}", file_path));
+    }
+    fs::write(&file_path, content)
+        .unwrap_or_else(|_| panic!("Failed to write include file {:?}", file_path));
+    println!("✅ Wrote include file: {:?}", file_path);
+}


### PR DESCRIPTION
# Add `.include` directive for multi-file assembly

## Summary

Adds support for `.include "path"` in sBPF assembly, allowing programs to be split across multiple files. Rewritten against reviewer feedback from @clairechingching and @deanmlittle.

## Design

`.include` is handled inside the assembler parser (`parser::directive`), not as text expansion in `build.rs`. When the parser encounters `.include "path"` it reads the file, parses it recursively into the same `AST` with a swapped `current_file` / `base_path`, and pushes an entry on an `include_stack` that is used to annotate diagnostics.

* **Pure inlining** — `.include` is treated as textual inclusion, not import. There is no label prefixing and no special handling of `.globl` / `.global` in included files. Duplicate symbols produce a normal `DuplicateLabel` error.
* **Paths** are resolved relative to the file containing the `.include` directive, so nested includes work naturally.
* **Source file/line tracking** is preserved for DWARF: each instruction and label carries the file it came from via a parallel `code_file_info` / `label_file_info` map, which is fed into a multi-file DWARF line program (`debug::DebugData::{lines_multi, labels_multi}`). `sbpf debug -g` now maps instructions back to the correct included `.s` file.
* **Duplicate-label diagnostics** are multi-file: the primary span is the redefinition in its own file, the secondary span is the original definition in its own file, and tertiary spans point at every `.include` directive in the chain that pulled in the duplicate.

## Shape of the diagnostic

Example with two included files that both define `helper`:

```
error: Duplicate label 'helper'
  ┌─ second.s:2:1
  │
2 │ helper:
  │ ^^^^^^ Label already defined
  │
  ┌─ first.s:2:1
  │
2 │ helper:
  │ ------ previous definition is here
  │
  ┌─ main.s:3:1
  │
3 │ .include "second.s"
  │ ------------------- included from here
```

## Changes

**Grammar**

- `crates/assembler/src/sbpf.pest`: new `directive_include` rule, added to `directive_inner` (shared by `program_default` and `program_llvm`).

**Parser**

- `crates/assembler/src/parser/mod.rs`:
  - New `parse_with_base_path(source, arch, base_path, main_file_name, sources_out) -> Result<ParseResult, _>` entry point.
  - `ParseContext` gains `base_path`, `current_file`, `include_stack`, `files`, `code_file_info`, `rodata_file_info`, `label_file_info`.
  - `label_spans` now keys `LabelLocation { file, span }` instead of bare `Range<usize>`.
  - New `process_source` helper used both for the main file and recursively for each included file.
- `crates/assembler/src/parser/directive.rs`:
  - New `Rule::directive_include` handler reads the file, swaps context state, pushes the include site on `include_stack`, recursively parses the included source, then restores state.
- `crates/assembler/src/errors.rs`:
  - New `DuplicateLabelMulti` struct (boxed inside the variant to keep `CompileError` small for the single-file path).
  - `DuplicateLabel` extended with `multi: Option<Box<DuplicateLabelMulti>>` carrying the two file names and the include chain.

**Assembler API**

- `crates/assembler/src/lib.rs`:
  - New `AssembleResult { sources, bytecode }` carrying the full source registry back to the caller on both success and failure.
  - New `Assembler::assemble_with_base_path(main_file_name, source, base_path)` method.
  - New `collect_multi_file_line_entries` helper that builds a `codespan::Files` over every read source and emits per-file line numbers for DWARF.

**Debug info**

- `crates/assembler/src/debug.rs`:
  - `DebugData` gains `lines_multi` / `labels_multi`.
  - `generate_dwarf_sections` registers a DWARF file entry per distinct source and emits rows with the correct `file_id` when multi-file data is present; falls back to single-file otherwise.

**Build command**

- `src/commands/build.rs`:
  - Switched from `SimpleFile` to `SimpleFiles` so diagnostic labels can resolve to different files.
  - New `AsDiagnostic` trait signature: `to_diagnostic(default_file_id, resolve)`, where `resolve: Fn(&str) -> usize` maps parser file identifiers to `SimpleFiles` file ids.
  - `compile_assembly` now calls `assemble_with_base_path` and builds the `SimpleFiles` registry from `AssembleResult.sources`.

**Tests**

- `tests/test_include.rs` (new, 9 tests):
  - `test_include_directive` — basic include.
  - `test_include_nested` — nested includes.
  - `test_include_nested_resolves_relative_to_including_file` — path resolution.
  - `test_include_allows_globl_in_included_file` — `.globl` / `.global` permitted everywhere.
  - `test_include_missing_file_fails` — missing file error text.
  - `test_include_duplicate_label_main_then_included` — main + include duplicate, with include chain.
  - `test_include_duplicate_label_between_two_includes` — both definitions inside included files.
  - `test_include_duplicate_label_same_file_no_chain` — same-file duplicates don't report any `.include` chain.
  - `test_include_duplicate_rodata_label` — regression against the old "prefix data labels" behaviour.
- `tests/utils.rs`: new `write_include_file` helper.

## Reviewer feedback mapping

| Requirement | Addressed by |
|---|---|
| @clairechingching: `.include` in assembler, not `build.rs` | `parser::directive::process_directive_include` |
| @clairechingching: included files → same AST | `process_source` recurses into `ctx`, no separate AST |
| @clairechingching: preserve file/line for debug | `lines_multi` / `labels_multi` + multi-file DWARF |
| @clairechingching: `build.rs` = I/O + config + assembler call | `build.rs` rewritten to exactly that |
| @deanmlittle: pure inlining, no prefixing | Removed from previous PR commits |
| @deanmlittle: allow `.globl` in includes | No check at all; `.globl` / `.global` work everywhere |
| @deanmlittle: duplicate error with file+line for both | `DuplicateLabel { multi: Some(Box<DuplicateLabelMulti>) }` + multi-file rendering |
| @deanmlittle: error over the `.include` statement when duplicate comes from include | `include_chain` tertiary labels in the diagnostic |
| @deanmlittle: works with master | PR rebased onto current `master` |
| @deanmlittle: VSCode plugin integration | DWARF verified with `dwarfdump --debug-line` across three demos; extension changes are follow-up |

## Checklist

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features --all-targets` passes (509 tests, including 9 new in `tests/test_include.rs`)
