### PR TITLE
feat: analyzer and optimizer lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,13 @@ toml = { workspace = true }
 
 [workspace]
 members = [
+    "crates/analyzer",
     "crates/assembler",
     "crates/common",
     "crates/disassembler",
     "crates/debugger",
     "crates/runtime",
+    "crates/sbpf_ir",
     "crates/sbpf-syscall-map",
     "crates/vm",
     "examples/*",
@@ -71,6 +73,7 @@ gimli = { version = "0.33.0", features = ["write"] }
 object = "0.38.1"
 serde_json = "1.0.122"
 serde = { version = "1.0", features = ["derive"] }
+smallvec = "1.13"
 thiserror = "2.0.12"
 bs58 = "0.5"
 sha2 = "0.10"
@@ -97,8 +100,10 @@ sbpf-assembler = { path = "crates/assembler", version = "0.2.2" }
 sbpf-disassembler = { path = "crates/disassembler", version = "0.2.2" }
 sbpf-debugger = { path = "crates/debugger", version = "0.2.2" }
 sbpf-common = { path = "crates/common", version = "0.2.2" }
-sbpf-syscall-map = { path = "crates/sbpf-syscall-map", version = "0.2.2" }
+sbpf-ir = { path = "crates/sbpf_ir", version = "0.2.2" }
 sbpf-runtime = { path = "crates/runtime", version = "0.2.2" }
+sbpf-syscall-map = { path = "crates/sbpf-syscall-map", version = "0.2.2" }
+sbpf-transform = { path = "crates/analyzer", version = "0.2.2" }
 sbpf-vm = { path = "crates/vm", version = "0.2.2" }
 mollusk-svm = "0.13.4"
 mollusk-svm-programs-token = "0.13.1"

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sbpf-transform"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Transform passes for SBPF assembly programs"
+keywords = ["solana", "bpf", "analysis", "cfg"]
+categories = ["development-tools", "compilers"]
+rust-version.workspace = true
+
+[lib]
+name = "sbpf_transform"
+
+[dependencies]
+sbpf-common = { workspace = true }
+sbpf-ir = { workspace = true }
+smallvec = { workspace = true }
+
+[dev-dependencies]
+either = { workspace = true }

--- a/crates/analyzer/src/dump_cfg.rs
+++ b/crates/analyzer/src/dump_cfg.rs
@@ -1,0 +1,129 @@
+use {
+    sbpf_common::instruction::AsmFormat,
+    sbpf_ir::{Cfg, graph_engine::DfsEngine},
+    std::fmt::Write,
+};
+
+pub fn dump_cfg(cfg: &Cfg) -> String {
+    let mut output = String::from("digraph cfg {\n  node [shape=box];\n");
+
+    // Emit one DOT subgraph cluster per function, with each block declared inside
+    // so Graphviz renders blocks visually grouped by their containing function.
+    for (function_id, function) in cfg.functions().iter().enumerate() {
+        writeln!(output, "  subgraph cluster_function_{function_id} {{")
+            .expect("writing to a String cannot fail");
+        writeln!(
+            output,
+            "    label=\"{}\";",
+            escape_dot_label(function.name())
+        )
+        .expect("writing to a String cannot fail");
+
+        for (&block_id, block) in function.block_ids().iter().zip(function.blocks().iter()) {
+            let inst_base = cfg.block_inst_offset(block_id);
+            writeln!(
+                output,
+                "    block_{block_id} [label=\"{}\"];",
+                block_label(block_id, inst_base, block)
+            )
+            .expect("writing to a String cannot fail");
+        }
+
+        output.push_str("  }\n");
+    }
+
+    // DFS from every function entry to emit control-flow edges between blocks.
+    let entry_blocks = cfg
+        .functions()
+        .iter()
+        .filter_map(|f| f.block_ids().first().copied());
+    DfsEngine::new(cfg).visit_many(entry_blocks, &mut |block_id| {
+        for successor in cfg.successors(block_id) {
+            writeln!(output, "  block_{block_id} -> block_{successor};")
+                .expect("writing to a String cannot fail");
+        }
+    });
+
+    output.push_str("}\n");
+    output
+}
+
+fn block_label(block_id: usize, inst_base: usize, block: &sbpf_ir::Block) -> String {
+    let mut label = format!("block {block_id}\\l");
+
+    if !block.labels().is_empty() {
+        let labels = block
+            .labels()
+            .iter()
+            .map(|(name, _)| escape_dot_label(name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(label, "labels: {labels}\\l").expect("writing to a String cannot fail");
+    }
+
+    for (local_idx, node) in block.instructions().iter().enumerate() {
+        let inst_id = inst_base + local_idx;
+        let asm = node
+            .instruction()
+            .and_then(|inst| inst.to_asm(AsmFormat::Default).ok())
+            .unwrap_or_else(|| node.opcode.to_string());
+        write!(label, "{inst_id}: {asm}\\l").expect("writing to a String cannot fail");
+    }
+
+    label
+}
+
+fn escape_dot_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        either::Either,
+        sbpf_common::{instruction::Instruction, opcode::Opcode},
+        sbpf_ir::{InputNode, control_flow_graph},
+        std::collections::HashSet,
+    };
+
+    #[test]
+    fn test_dump_cfg_writes_function_clusters_and_edges() {
+        let jump = instruction(Opcode::Ja, Some(Either::Left("target".to_string())));
+        let dead_exit = instruction(Opcode::Exit, None);
+        let target_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&jump),
+            InputNode::Instruction(&dead_exit),
+            InputNode::Label("target"),
+            InputNode::Instruction(&target_exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string(), "target".to_string()]);
+        let cfg = control_flow_graph(nodes, &function_entries, None);
+
+        let dot = dump_cfg(&cfg);
+
+        assert!(dot.starts_with("digraph cfg {\n"));
+        assert!(dot.contains("subgraph cluster_function_0"));
+        assert!(dot.contains("label=\"entrypoint\";"));
+        assert!(dot.contains("subgraph cluster_function_1"));
+        assert!(dot.contains("label=\"target\";"));
+        assert!(dot.contains("0: ja target\\l"));
+        assert!(dot.contains("block_0 -> block_2;"));
+    }
+
+    fn instruction(opcode: Opcode, off: Option<Either<String, i16>>) -> Instruction {
+        Instruction {
+            opcode,
+            dst: None,
+            src: None,
+            off,
+            imm: None,
+            span: 0..0,
+        }
+    }
+}

--- a/crates/analyzer/src/lib.rs
+++ b/crates/analyzer/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod dump_cfg;
+pub mod remove_dead_functions;
+
+pub use {
+    dump_cfg::dump_cfg,
+    remove_dead_functions::{RemovedFunction, remove_dead_functions},
+};

--- a/crates/analyzer/src/remove_dead_functions.rs
+++ b/crates/analyzer/src/remove_dead_functions.rs
@@ -1,0 +1,222 @@
+use {
+    sbpf_ir::{
+        BlockId, Cfg, CfgFunction, FunctionId,
+        graph_engine::{WorklistEngine, WorklistVisitor},
+    },
+    std::collections::HashSet,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemovedFunction {
+    pub name: String,
+    /// Indices into the original `ast.nodes` array for every node (labels and
+    /// instructions) that belonged to this function. Used by the assembler to
+    /// strip the corresponding AST nodes after DCE.
+    pub node_ids: Vec<usize>,
+}
+
+/// Removes functions not reachable from `functions()[0]` via `call imm` edges and returns
+/// their names and byte ranges. Dead functions' blocks and instructions are dropped automatically
+/// via Rust ownership. Successor/predecessor relationships between live blocks are
+/// unchanged and are NOT rebuilt.
+pub fn remove_dead_functions(cfg: &mut Cfg) -> Vec<RemovedFunction> {
+    if cfg.functions.is_empty() {
+        return Vec::new();
+    }
+
+    let reachable_funcs = reachable_functions(cfg);
+
+    if reachable_funcs.len() == cfg.functions.len() {
+        return Vec::new();
+    }
+
+    let old_functions = std::mem::take(&mut cfg.functions);
+    let mut removed_functions = Vec::new();
+
+    cfg.functions = old_functions
+        .into_iter()
+        .enumerate()
+        .filter_map(|(fi, func)| {
+            if reachable_funcs.contains(&fi) {
+                Some(func)
+            } else {
+                removed_functions.push(RemovedFunction {
+                    name: func.name.clone(),
+                    node_ids: function_node_ids(&func),
+                });
+                None
+            }
+        })
+        .collect();
+
+    removed_functions
+}
+
+fn function_node_ids(function: &CfgFunction) -> Vec<usize> {
+    function
+        .blocks()
+        .iter()
+        .flat_map(|block| block.node_ids().iter().copied())
+        .collect()
+}
+
+fn reachable_functions(cfg: &Cfg) -> HashSet<FunctionId> {
+    // functions()[0] is always the declared entry (guaranteed by control_flow_graph).
+    let entry_fi = 0;
+
+    // When the engine crosses into a new function, enqueue ALL of its blocks —
+    // not just the entry block. This ensures that unreachable-within-function code
+    // (dead blocks inside a live function) is also traversed, so calls from that
+    // dead code don't cause the callee to be incorrectly removed.
+    struct EnqueueFunctionBlocks<'a> {
+        cfg: &'a Cfg,
+        enqueued_funcs: HashSet<FunctionId>,
+    }
+
+    impl<'a> WorklistVisitor<BlockId> for EnqueueFunctionBlocks<'a> {
+        fn visit(&mut self, block_id: BlockId, enqueue: &mut dyn FnMut(BlockId)) {
+            let caller_fi = self.cfg.function_of_block(block_id);
+            for &succ in self.cfg.successors(block_id) {
+                let Some(callee_fi) = self.cfg.function_of_block(succ) else {
+                    continue;
+                };
+                if Some(callee_fi) != caller_fi && self.enqueued_funcs.insert(callee_fi) {
+                    for &blk in self.cfg.functions()[callee_fi].block_ids() {
+                        enqueue(blk);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut visitor = EnqueueFunctionBlocks {
+        cfg,
+        enqueued_funcs: HashSet::from([entry_fi]),
+    };
+
+    let mut engine = WorklistEngine::new(cfg);
+    engine.initialize(cfg.functions()[entry_fi].block_ids().iter().copied());
+    engine.run(&mut visitor);
+
+    // Every function that had at least one block visited is reachable.
+    engine
+        .visited()
+        .iter()
+        .filter_map(|&b| cfg.function_of_block(b))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        either::Either,
+        sbpf_common::{instruction::Instruction, opcode::Opcode},
+        sbpf_ir::{InputNode, control_flow_graph},
+        std::collections::HashSet,
+    };
+
+    #[test]
+    fn test_remove_dead_functions_removes_unreachable_function() {
+        let call = call_instruction("callee");
+        let entry_exit = instruction(Opcode::Exit, None);
+        let dead_exit = instruction(Opcode::Exit, None);
+        let callee_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&call),
+            InputNode::Instruction(&entry_exit),
+            InputNode::Label("dead"),
+            InputNode::Instruction(&dead_exit),
+            InputNode::Label("callee"),
+            InputNode::Instruction(&callee_exit),
+        ];
+        let function_entries = HashSet::from([
+            "entrypoint".to_string(),
+            "dead".to_string(),
+            "callee".to_string(),
+        ]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "dead");
+        assert_eq!(cfg.functions().len(), 2);
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+        assert_eq!(cfg.functions()[1].name(), "callee");
+    }
+
+    #[test]
+    fn test_remove_dead_functions_keeps_all_reachable() {
+        let exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string()]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert!(removed.is_empty());
+        assert_eq!(cfg.functions().len(), 1);
+    }
+
+    /// Regression: a `call` in dead code inside a live function must not cause
+    /// the callee to be treated as unreachable and removed.
+    ///
+    /// Layout:
+    ///   entrypoint:  ja target   -- skips the call
+    ///   [dead block] call hidden  -- never reached via CFG from block 0
+    ///   target:      exit
+    ///   hidden:      exit         -- only referenced from dead code
+    #[test]
+    fn test_remove_dead_functions_keeps_callee_of_dead_block_in_live_function() {
+        let jump = instruction(Opcode::Ja, Some(Either::Left("target".to_string())));
+        let dead_call = call_instruction("hidden");
+        let target_exit = instruction(Opcode::Exit, None);
+        let hidden_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&jump),
+            InputNode::Instruction(&dead_call),
+            InputNode::Label("target"),
+            InputNode::Instruction(&target_exit),
+            InputNode::Label("hidden"),
+            InputNode::Instruction(&hidden_exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string(), "hidden".to_string()]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert!(
+            removed.is_empty(),
+            "expected no dead functions, got: {removed:?}"
+        );
+        assert_eq!(cfg.functions().len(), 2);
+    }
+
+    fn instruction(opcode: Opcode, off: Option<Either<String, i16>>) -> Instruction {
+        Instruction {
+            opcode,
+            dst: None,
+            src: None,
+            off,
+            imm: None,
+            span: 0..0,
+        }
+    }
+
+    fn call_instruction(target: &str) -> Instruction {
+        Instruction {
+            opcode: Opcode::Call,
+            dst: None,
+            src: None,
+            off: None,
+            imm: Some(Either::Left(target.to_string())),
+            span: 0..0,
+        }
+    }
+}

--- a/crates/analyzer/src/remove_dead_functions.rs
+++ b/crates/analyzer/src/remove_dead_functions.rs
@@ -219,4 +219,143 @@ mod tests {
             span: 0..0,
         }
     }
+
+    #[test]
+    fn test_remove_dead_functions_keeps_self_recursive_function() {
+        let self_call = call_instruction("entrypoint");
+        let exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&self_call),
+            InputNode::Instruction(&exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string()]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        // Verify the self-loop edge was actually created before running DFE.
+        // entrypoint is block 0; the call back to itself must produce edge 0 -> 0.
+        assert!(
+            cfg.successors(0).contains(&0),
+            "self-loop edge 0 -> 0 must exist for a self-recursive call"
+        );
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert!(
+            removed.is_empty(),
+            "self-recursive function should not be removed"
+        );
+        assert_eq!(cfg.functions().len(), 1);
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+    }
+
+    #[test]
+    fn test_remove_dead_functions_keeps_mutually_recursive_functions() {
+        let call_helper = call_instruction("helper");
+        let entry_exit = instruction(Opcode::Exit, None);
+        let call_back = call_instruction("entrypoint");
+        let helper_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&call_helper),
+            InputNode::Instruction(&entry_exit),
+            InputNode::Label("helper"),
+            InputNode::Instruction(&call_back),
+            InputNode::Instruction(&helper_exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string(), "helper".to_string()]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        // entrypoint=block 0, helper=block 1.
+        // Verify both directions of the cycle exist before running DFE.
+        assert!(
+            cfg.successors(0).contains(&1),
+            "entrypoint must have a call edge to helper"
+        );
+        assert!(
+            cfg.successors(1).contains(&0),
+            "helper must have a back-edge to entrypoint"
+        );
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert!(
+            removed.is_empty(),
+            "mutually recursive functions should not be removed"
+        );
+        assert_eq!(cfg.functions().len(), 2);
+    }
+
+    #[test]
+    fn test_remove_dead_functions_removes_unreachable_self_recursive_function() {
+        let entry_exit = instruction(Opcode::Exit, None);
+        let dead_self_call = call_instruction("dead");
+        let dead_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&entry_exit),
+            InputNode::Label("dead"),
+            InputNode::Instruction(&dead_self_call),
+            InputNode::Instruction(&dead_exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string(), "dead".to_string()]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        // entrypoint=block 0, dead=block 1. Verify the self-loop exists before DFE.
+        assert!(
+            cfg.successors(1).contains(&1),
+            "dead function must have a self-loop edge 1 -> 1"
+        );
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "dead");
+        assert_eq!(cfg.functions().len(), 1);
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+    }
+
+    #[test]
+    fn test_remove_dead_functions_removes_unreachable_mutually_recursive_functions() {
+        let entry_exit = instruction(Opcode::Exit, None);
+        let call_b = call_instruction("dead_b");
+        let dead_a_exit = instruction(Opcode::Exit, None);
+        let call_a = call_instruction("dead_a");
+        let dead_b_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&entry_exit),
+            InputNode::Label("dead_a"),
+            InputNode::Instruction(&call_b),
+            InputNode::Instruction(&dead_a_exit),
+            InputNode::Label("dead_b"),
+            InputNode::Instruction(&call_a),
+            InputNode::Instruction(&dead_b_exit),
+        ];
+        let function_entries = HashSet::from([
+            "entrypoint".to_string(),
+            "dead_a".to_string(),
+            "dead_b".to_string(),
+        ]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        // entrypoint=block 0, dead_a=block 1, dead_b=block 2.
+        // Verify both directions of the dead cycle exist before DFE.
+        assert!(
+            cfg.successors(1).contains(&2),
+            "dead_a must have a call edge to dead_b"
+        );
+        assert!(
+            cfg.successors(2).contains(&1),
+            "dead_b must have a back-edge to dead_a"
+        );
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert_eq!(removed.len(), 2);
+        assert!(removed.iter().any(|f| f.name == "dead_a"));
+        assert!(removed.iter().any(|f| f.name == "dead_b"));
+        assert_eq!(cfg.functions().len(), 1);
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+    }
 }

--- a/crates/assembler/Cargo.toml
+++ b/crates/assembler/Cargo.toml
@@ -20,6 +20,8 @@ num-traits = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 sbpf-common = { workspace = true }
+sbpf-transform = { workspace = true }
+sbpf-ir = { workspace = true }
 phf = "0.13.1"
 phf_macros = "0.13.1"
 pest = "2.7"

--- a/crates/assembler/src/ast.rs
+++ b/crates/assembler/src/ast.rs
@@ -4,7 +4,8 @@ use {
         astnode::{ASTNode, ROData},
         dynsym::{DynamicSymbolMap, RelDynMap, RelocationType},
         header::ProgramHeader,
-        parser::ParseResult,
+        optimizer,
+        parser::ProgramLayout,
         section::{CodeSection, DataSection},
     },
     either::Either,
@@ -13,15 +14,53 @@ use {
         instruction::Instruction,
         opcode::Opcode,
     },
-    std::collections::HashMap,
+    std::{
+        collections::{HashMap, HashSet},
+        path::PathBuf,
+    },
     syscall_map::murmur3_32,
 };
+
+type LabelOffsetMap = HashMap<String, u64>;
+type NumericLabel = (String, u64, usize);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptimizationConfig {
+    Disabled,
+    Enabled { cfg_dump_dir: Option<PathBuf> },
+}
+
+impl Default for OptimizationConfig {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl OptimizationConfig {
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    pub fn enabled() -> Self {
+        Self::Enabled { cfg_dump_dir: None }
+    }
+
+    pub fn with_cfg_dump_dir(self, path: impl Into<PathBuf>) -> Self {
+        match self {
+            Self::Enabled { .. } => Self::Enabled {
+                cfg_dump_dir: Some(path.into()),
+            },
+            Self::Disabled => Self::Disabled,
+        }
+    }
+}
 
 #[derive(Default, Debug)]
 pub struct AST {
     pub nodes: Vec<ASTNode>,
     pub rodata_nodes: Vec<ASTNode>,
 
+    function_entries: HashSet<String>,
     text_size: u64,
     rodata_size: u64,
 }
@@ -29,6 +68,14 @@ pub struct AST {
 impl AST {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn add_function_entry(&mut self, name: String) {
+        self.function_entries.insert(name);
+    }
+
+    pub(crate) fn function_entries(&self) -> &HashSet<String> {
+        &self.function_entries
     }
 
     //
@@ -78,10 +125,10 @@ impl AST {
     }
 
     /// Resolve numeric label references (like "2f" or "1b")
-    fn resolve_numeric_label(
+    pub(crate) fn resolve_numeric_label(
         label_ref: &str,
         current_idx: usize,
-        numeric_labels: &[(String, u64, usize)],
+        numeric_labels: &[NumericLabel],
     ) -> Option<u64> {
         if let Some(direction) = label_ref.chars().last()
             && (direction == 'f' || direction == 'b')
@@ -106,186 +153,265 @@ impl AST {
         }
         None
     }
+}
 
-    pub fn build_program(&mut self, arch: SbpfArch) -> Result<ParseResult, Vec<CompileError>> {
-        let mut label_offset_map: HashMap<String, u64> = HashMap::new();
-        let mut numeric_labels: Vec<(String, u64, usize)> = Vec::new();
+pub fn build_program(
+    mut ast: AST,
+    arch: SbpfArch,
+    optimization: OptimizationConfig,
+) -> Result<ProgramLayout, Vec<CompileError>> {
+    let optimization = run_optimizations(&mut ast, &optimization);
+    let mut errors = optimization.errors;
 
-        // iterate through text labels and rodata labels and find the pair
-        // of each label and offset
-        for (idx, node) in self.nodes.iter().enumerate() {
-            if let ASTNode::Label { label, offset } = node {
-                label_offset_map.insert(label.name.clone(), *offset);
-                // Also track numeric labels separately for forward/backward resolution
-                numeric_labels.push((label.name.clone(), *offset, idx));
-            }
-        }
-
-        for node in &self.rodata_nodes {
-            if let ASTNode::ROData { rodata, offset } = node {
-                label_offset_map.insert(rodata.name.clone(), *offset + self.text_size);
-            }
-        }
-
-        // 1. resolve labels in the intruction nodes for lddw and jump
-        // 2. find relocation information
-
-        let mut relocations = RelDynMap::new();
-        let mut dynamic_symbols = DynamicSymbolMap::new();
-
-        let program_is_static = arch.is_v3()
-            || !self.nodes.iter().any(|node| {
-                matches!(node, ASTNode::Instruction { instruction: inst, .. }
-                    if inst.is_syscall()
-                    || (inst.opcode == Opcode::Lddw && matches!(&inst.imm, Some(Either::Left(_)))))
-            });
-
-        // Resolve both static and dynamic syscalls.
-        for node in self.nodes.iter_mut() {
-            if let ASTNode::Instruction {
-                instruction: inst,
-                offset,
-            } = node
-                && inst.is_syscall()
-                && let Some(Either::Left(syscall_name)) = &inst.imm
-            {
-                let syscall_name = syscall_name.clone();
-                if arch.is_v3() {
-                    // Static syscall: src = 0, imm = hash
-                    inst.src = Some(Register { n: 0 });
-                    inst.imm = Some(Either::Right(Number::Int(murmur3_32(&syscall_name) as i64)));
-                } else {
-                    // Dynamic syscall: src = 1, imm = -1
-                    inst.src = Some(Register { n: 1 });
-                    inst.imm = Some(Either::Right(Number::Int(-1)));
-
-                    // Add relocation for dynamic syscall
-                    relocations.add_rel_dyn(
-                        *offset,
-                        RelocationType::RSbfSyscall,
-                        syscall_name.clone(),
-                    );
-                    dynamic_symbols.add_call_target(syscall_name.clone(), *offset);
-                }
-            }
-        }
-
-        let mut errors = Vec::new();
-
-        for (idx, node) in self.nodes.iter_mut().enumerate() {
-            if let ASTNode::Instruction {
-                instruction: inst,
-                offset,
-                ..
-            } = node
-            {
-                // For jump/call instructions, replace label with relative offsets
-                if inst.is_jump()
-                    && let Some(Either::Left(label)) = &inst.off
-                {
-                    let target_offset = if let Some(offset) = label_offset_map.get(label) {
-                        Some(*offset)
-                    } else {
-                        // Handle numeric label references
-                        Self::resolve_numeric_label(label, idx, &numeric_labels)
-                    };
-
-                    if let Some(target_offset) = target_offset {
-                        let rel_offset = (target_offset as i64 - *offset as i64) / 8 - 1;
-                        inst.off = Some(Either::Right(rel_offset as i16));
-                    } else {
-                        errors.push(CompileError::UndefinedLabel {
-                            label: label.clone(),
-                            span: inst.span.clone(),
-                            custom_label: None,
-                        });
-                    }
-                } else if inst.opcode == Opcode::Call
-                    && let Some(Either::Left(label)) = &inst.imm
-                    && let Some(target_offset) = label_offset_map.get(label)
-                {
-                    let rel_offset = (*target_offset as i64 - *offset as i64) / 8 - 1;
-                    inst.src = Some(Register { n: 1 });
-                    inst.imm = Some(Either::Right(Number::Int(rel_offset)));
-                }
-
-                if inst.opcode == Opcode::Lddw
-                    && let Some(Either::Left(name)) = &inst.imm
-                {
-                    let label = name.clone();
-                    // Add relocation for lddw (only for v0)
-                    if !arch.is_v3() {
-                        relocations.add_rel_dyn(
-                            *offset,
-                            RelocationType::RSbf64Relative,
-                            label.clone(),
-                        );
-                    }
-
-                    if let Some(target_offset) = label_offset_map.get(&label) {
-                        let abs_offset = if arch.is_v3() {
-                            if *target_offset >= self.text_size {
-                                // rodata label
-                                (ProgramHeader::V3_RODATA_VADDR + *target_offset - self.text_size)
-                                    as i64
-                            } else {
-                                // text label
-                                (ProgramHeader::V3_BYTECODE_VADDR + *target_offset) as i64
-                            }
-                        } else {
-                            let ph_count = if program_is_static { 1 } else { 3 };
-                            let ph_offset = 64 + (ph_count as u64 * 56) as i64;
-                            *target_offset as i64 + ph_offset
-                        };
-                        // Replace label with immediate value
-                        inst.imm = Some(Either::Right(Number::Addr(abs_offset)));
-                    } else {
-                        errors.push(CompileError::UndefinedLabel {
-                            label: name.clone(),
-                            span: inst.span.clone(),
-                            custom_label: None,
-                        });
-                    }
-                }
-            }
-        }
-
-        // Set entry point offset if a GlobalDecl was specified
-        let entry_label = self.nodes.iter().find_map(|node| {
-            if let ASTNode::GlobalDecl { global_decl } = node {
-                Some(global_decl.entry_label.clone())
-            } else {
-                None
-            }
+    let (label_offset_map, numeric_labels) = label_offset_map(&ast);
+    let program_is_static = arch.is_v3()
+        || !ast.nodes.iter().any(|node| {
+            matches!(node, ASTNode::Instruction { instruction: inst, .. }
+                if inst.is_syscall()
+                || (inst.opcode == Opcode::Lddw && matches!(&inst.imm, Some(Either::Left(_)))))
         });
-        if let Some(entry_label) = entry_label
-            && let Some(offset) = label_offset_map.get(&entry_label)
-        {
-            dynamic_symbols.add_entry_point(entry_label, *offset);
-        }
 
-        if !errors.is_empty() {
-            Err(errors)
+    let label_resolution = resolve_label_references(
+        &mut ast,
+        arch,
+        program_is_static,
+        &label_offset_map,
+        &numeric_labels,
+    );
+    errors.extend(label_resolution.errors);
+
+    optimizer::remove_temp_control_flow_target_labels(
+        &mut ast.nodes,
+        &optimization.labels_to_remove,
+    );
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        Ok(ProgramLayout {
+            code_section: CodeSection::new(std::mem::take(&mut ast.nodes), ast.text_size),
+            data_section: DataSection::new(std::mem::take(&mut ast.rodata_nodes), ast.rodata_size),
+            dynamic_symbols: label_resolution.dynamic_symbols,
+            relocation_data: label_resolution.relocations,
+            prog_is_static: program_is_static,
+            arch,
+            debug_sections: Vec::default(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct OptimizationOutcome {
+    labels_to_remove: HashSet<String>,
+    errors: Vec<CompileError>,
+}
+
+fn run_optimizations(ast: &mut AST, config: &OptimizationConfig) -> OptimizationOutcome {
+    let OptimizationConfig::Enabled { cfg_dump_dir } = config else {
+        return OptimizationOutcome::default();
+    };
+
+    // Normalize numeric and relative control-flow targets to labels before running
+    // CFG-based optimizations. Synthetic labels are tracked so they can be removed
+    // after optimization, and the pass is skipped if normalization fails.
+    let canonicalized_targets = optimizer::canonicalize_control_flow_targets(&mut ast.nodes);
+    let labels_to_remove = canonicalized_targets.labels_to_remove;
+    let mut errors = Vec::new();
+
+    if canonicalized_targets.errors.is_empty() {
+        if let Some(dump_dir) = cfg_dump_dir.as_deref() {
+            let mut dump_errors = Vec::new();
+            if let Err(error) = std::fs::create_dir_all(dump_dir) {
+                dump_errors.push((dump_dir.to_path_buf(), error));
+                optimizer::eliminate_unreachable_functions(ast);
+            } else {
+                optimizer::eliminate_unreachable_functions_with_observer(ast, |stage, cfg| {
+                    let path = dump_dir.join(stage.file_name());
+                    if let Err(error) = std::fs::write(&path, sbpf_transform::dump_cfg(cfg)) {
+                        dump_errors.push((path, error));
+                    }
+                });
+            }
+            for (path, error) in dump_errors {
+                errors.push(CompileError::BytecodeError {
+                    error: format!("failed to write CFG dump '{}': {error}", path.display()),
+                    span: 0..0,
+                    custom_label: None,
+                });
+            }
         } else {
-            Ok(ParseResult {
-                code_section: CodeSection::new(std::mem::take(&mut self.nodes), self.text_size),
-                data_section: DataSection::new(
-                    std::mem::take(&mut self.rodata_nodes),
-                    self.rodata_size,
-                ),
-                dynamic_symbols,
-                relocation_data: relocations,
-                prog_is_static: program_is_static,
-                arch,
-                debug_sections: Vec::default(),
-            })
+            optimizer::eliminate_unreachable_functions(ast);
         }
     }
+
+    OptimizationOutcome {
+        labels_to_remove,
+        errors,
+    }
+}
+
+#[derive(Default)]
+struct LabelResolution {
+    dynamic_symbols: DynamicSymbolMap,
+    relocations: RelDynMap,
+    errors: Vec<CompileError>,
+}
+
+fn resolve_label_references(
+    ast: &mut AST,
+    arch: SbpfArch,
+    program_is_static: bool,
+    label_offset_map: &LabelOffsetMap,
+    numeric_labels: &[NumericLabel],
+) -> LabelResolution {
+    let mut relocations = RelDynMap::new();
+    let mut dynamic_symbols = DynamicSymbolMap::new();
+    let mut errors = Vec::new();
+
+    // Resolve both static and dynamic syscalls.
+    for node in ast.nodes.iter_mut() {
+        if let ASTNode::Instruction {
+            instruction: inst,
+            offset,
+        } = node
+            && inst.is_syscall()
+            && let Some(Either::Left(syscall_name)) = &inst.imm
+        {
+            let syscall_name = syscall_name.clone();
+            if arch.is_v3() {
+                // Static syscall: src = 0, imm = hash
+                inst.src = Some(Register { n: 0 });
+                inst.imm = Some(Either::Right(Number::Int(murmur3_32(&syscall_name) as i64)));
+            } else {
+                // Dynamic syscall: src = 1, imm = -1
+                inst.src = Some(Register { n: 1 });
+                inst.imm = Some(Either::Right(Number::Int(-1)));
+
+                // Add relocation for dynamic syscall
+                relocations.add_rel_dyn(*offset, RelocationType::RSbfSyscall, syscall_name.clone());
+                dynamic_symbols.add_call_target(syscall_name.clone(), *offset);
+            }
+        }
+    }
+
+    for (idx, node) in ast.nodes.iter_mut().enumerate() {
+        if let ASTNode::Instruction {
+            instruction: inst,
+            offset,
+            ..
+        } = node
+        {
+            // For jump/call instructions, replace label with relative offsets
+            if inst.is_jump()
+                && let Some(Either::Left(label)) = &inst.off
+            {
+                let target_offset = if let Some(offset) = label_offset_map.get(label) {
+                    Some(*offset)
+                } else {
+                    // Handle numeric label references
+                    AST::resolve_numeric_label(label, idx, numeric_labels)
+                };
+
+                if let Some(target_offset) = target_offset {
+                    let rel_offset = (target_offset as i64 - *offset as i64) / 8 - 1;
+                    inst.off = Some(Either::Right(rel_offset as i16));
+                } else {
+                    errors.push(CompileError::UndefinedLabel {
+                        label: label.clone(),
+                        span: inst.span.clone(),
+                        custom_label: None,
+                    });
+                }
+            } else if inst.opcode == Opcode::Call
+                && let Some(Either::Left(label)) = &inst.imm
+                && let Some(target_offset) = label_offset_map.get(label)
+            {
+                let rel_offset = (*target_offset as i64 - *offset as i64) / 8 - 1;
+                inst.src = Some(Register { n: 1 });
+                inst.imm = Some(Either::Right(Number::Int(rel_offset)));
+            }
+
+            if inst.opcode == Opcode::Lddw
+                && let Some(Either::Left(name)) = &inst.imm
+            {
+                let label = name.clone();
+                // Add relocation for lddw (only for v0)
+                if !arch.is_v3() {
+                    relocations.add_rel_dyn(*offset, RelocationType::RSbf64Relative, label.clone());
+                }
+
+                if let Some(target_offset) = label_offset_map.get(&label) {
+                    let abs_offset = if arch.is_v3() {
+                        if *target_offset >= ast.text_size {
+                            (ProgramHeader::V3_RODATA_VADDR + *target_offset - ast.text_size) as i64
+                        } else {
+                            (ProgramHeader::V3_BYTECODE_VADDR + *target_offset) as i64
+                        }
+                    } else {
+                        let ph_count = if program_is_static { 1 } else { 3 };
+                        let ph_offset = 64 + (ph_count as u64 * 56) as i64;
+                        *target_offset as i64 + ph_offset
+                    };
+                    // Replace label with immediate value
+                    inst.imm = Some(Either::Right(Number::Addr(abs_offset)));
+                } else {
+                    errors.push(CompileError::UndefinedLabel {
+                        label: name.clone(),
+                        span: inst.span.clone(),
+                        custom_label: None,
+                    });
+                }
+            }
+        }
+    }
+
+    // Set entry point offset if a GlobalDecl was specified
+    let entry_label = ast.nodes.iter().find_map(|node| {
+        if let ASTNode::GlobalDecl { global_decl } = node {
+            Some(global_decl.entry_label.clone())
+        } else {
+            None
+        }
+    });
+    if let Some(entry_label) = entry_label
+        && let Some(offset) = label_offset_map.get(&entry_label)
+    {
+        dynamic_symbols.add_entry_point(entry_label, *offset);
+    }
+
+    LabelResolution {
+        dynamic_symbols,
+        relocations,
+        errors,
+    }
+}
+
+fn label_offset_map(ast: &AST) -> (LabelOffsetMap, Vec<NumericLabel>) {
+    let mut label_offset_map = HashMap::new();
+    let mut numeric_labels = Vec::new();
+
+    for (idx, node) in ast.nodes.iter().enumerate() {
+        if let ASTNode::Label { label, offset } = node {
+            label_offset_map.insert(label.name.clone(), *offset);
+            numeric_labels.push((label.name.clone(), *offset, idx));
+        }
+    }
+
+    for node in &ast.rodata_nodes {
+        if let ASTNode::ROData { rodata, offset } = node {
+            label_offset_map.insert(rodata.name.clone(), *offset + ast.text_size);
+        }
+    }
+
+    (label_offset_map, numeric_labels)
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::parser::Token};
+    use {
+        super::*,
+        crate::{astnode::Label, parser::Token},
+    };
 
     #[test]
     fn test_ast_new() {
@@ -308,18 +434,8 @@ mod tests {
     #[test]
     fn test_get_instruction_at_offset() {
         let mut ast = AST::new();
-        let inst = Instruction {
-            opcode: Opcode::Exit,
-            dst: None,
-            src: None,
-            off: None,
-            imm: None,
-            span: 0..4,
-        };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: inst,
-            offset: 0,
-        });
+        ast.nodes
+            .push(instruction_node(Opcode::Exit, 0, None, None));
 
         let found = ast.get_instruction_at_offset(0);
         assert!(found.is_some());
@@ -373,25 +489,148 @@ mod tests {
     }
 
     #[test]
-    fn test_build_program_simple() {
-        let mut ast = AST::new();
-        let inst = Instruction {
-            opcode: Opcode::Exit,
-            dst: None,
-            src: None,
-            off: None,
-            imm: None,
-            span: 0..4,
+    fn test_canonicalize_numeric_jump_target_to_label() {
+        let mut nodes = vec![
+            instruction_node(Opcode::Ja, 0, Some(Either::Left("1f".to_string())), None),
+            label_node("1", 8),
+            instruction_node(Opcode::Exit, 8, None, None),
+        ];
+
+        let canonicalized = optimizer::canonicalize_control_flow_targets(&mut nodes);
+
+        assert!(canonicalized.errors.is_empty());
+        assert!(canonicalized.labels_to_remove.is_empty());
+        let ASTNode::Instruction { instruction, .. } = &nodes[0] else {
+            panic!("expected instruction");
         };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: inst,
-            offset: 0,
-        });
-        ast.set_text_size(8);
+        assert_eq!(instruction.off, Some(Either::Left("1".to_string())));
+    }
+
+    #[test]
+    fn test_canonicalize_relative_jump_target_to_synthetic_label() {
+        let mut nodes = vec![
+            instruction_node(Opcode::Ja, 0, Some(Either::Right(1)), None),
+            instruction_node(Opcode::Exit, 8, None, None),
+            instruction_node(Opcode::Exit, 16, None, None),
+        ];
+
+        let canonicalized = optimizer::canonicalize_control_flow_targets(&mut nodes);
+
+        assert!(canonicalized.errors.is_empty());
+        assert_eq!(canonicalized.labels_to_remove.len(), 1);
+
+        let ASTNode::Instruction { instruction, .. } = &nodes[0] else {
+            panic!("expected instruction");
+        };
+        let Some(Either::Left(label)) = &instruction.off else {
+            panic!("expected canonical label target");
+        };
+        assert!(label.starts_with("temp_"));
+        assert!(canonicalized.labels_to_remove.contains(label));
+        assert!(
+            matches!(&nodes[2], ASTNode::Label { label: target_label, offset }
+                if target_label.name == *label && *offset == 16)
+        );
+    }
+
+    #[test]
+    fn test_canonicalize_rejects_invalid_relative_jump_target() {
+        let mut nodes = vec![
+            instruction_node(Opcode::Ja, 0, Some(Either::Right(1)), None),
+            instruction_node(Opcode::Exit, 8, None, None),
+        ];
+
+        let canonicalized = optimizer::canonicalize_control_flow_targets(&mut nodes);
+
+        assert_eq!(canonicalized.errors.len(), 1);
+        assert!(canonicalized.labels_to_remove.is_empty());
+        assert_eq!(nodes.len(), 2);
+        let ASTNode::Instruction { instruction, .. } = &nodes[0] else {
+            panic!("expected instruction");
+        };
+        assert_eq!(instruction.off, Some(Either::Right(1)));
+    }
+
+    #[test]
+    fn test_dce_recomputes_relative_call_target_after_removing_code() {
+        let mut ast = AST::new();
+        ast.add_function_entry("entrypoint".to_string());
+        ast.add_function_entry("dead".to_string());
+        ast.add_function_entry("target".to_string());
+        ast.nodes = vec![
+            label_node("entrypoint", 0),
+            internal_call_node(0, 2),
+            instruction_node(Opcode::Exit, 8, None, None),
+            label_node("dead", 16),
+            instruction_node(Opcode::Exit, 16, None, None),
+            label_node("target", 24),
+            instruction_node(Opcode::Exit, 24, None, None),
+        ];
+        ast.set_text_size(32);
+
+        let program_layout =
+            build_program(ast, SbpfArch::V0, OptimizationConfig::enabled()).unwrap();
+        let nodes = program_layout.code_section.get_nodes();
+
+        assert_eq!(
+            nodes
+                .iter()
+                .filter(|node| matches!(node, ASTNode::Instruction { .. }))
+                .count(),
+            3
+        );
+        assert!(matches!(
+            &nodes[1],
+            ASTNode::Instruction { instruction, offset }
+                if instruction.opcode == Opcode::Call
+                    && instruction.src == Some(Register { n: 1 })
+                    && instruction.imm == Some(Either::Right(Number::Int(1)))
+                    && *offset == 0
+        ));
+        assert!(matches!(
+            &nodes[3],
+            ASTNode::Label { label, offset } if label.name == "target" && *offset == 16
+        ));
+    }
+
+    #[test]
+    fn test_optimize_ast_removes_temp_jump_target_labels() {
+        let mut ast = AST::new();
+        ast.nodes = vec![
+            instruction_node(Opcode::Ja, 0, Some(Either::Right(1)), None),
+            instruction_node(Opcode::Exit, 8, None, None),
+            instruction_node(Opcode::Exit, 16, None, None),
+        ];
+        ast.set_text_size(24);
         ast.set_rodata_size(0);
 
+        let result = build_program(ast, SbpfArch::V0, OptimizationConfig::enabled());
+
+        assert!(result.is_ok());
+        let program_layout = result.unwrap();
+        assert!(!program_layout.code_section.get_nodes().iter().any(|node| {
+            matches!(node, ASTNode::Label { label, .. }
+                if label
+                    .name
+                    .starts_with("temp_"))
+        }));
+        let ASTNode::Instruction { instruction, .. } = &program_layout.code_section.get_nodes()[0]
+        else {
+            panic!("expected instruction");
+        };
+        assert_eq!(instruction.off, Some(Either::Right(1)));
+    }
+
+    #[test]
+    fn test_build_program_simple() {
         for arch in [SbpfArch::V0, SbpfArch::V3] {
-            let result = ast.build_program(arch);
+            let mut ast = AST::new();
+            ast.nodes
+                .push(instruction_node(Opcode::Exit, 0, None, None));
+            ast.set_text_size(8);
+            ast.set_rodata_size(0);
+
+            let result = build_program(ast, arch, OptimizationConfig::default());
             assert!(result.is_ok());
             let parse_result = result.unwrap();
             assert!(parse_result.prog_is_static);
@@ -400,25 +639,17 @@ mod tests {
 
     #[test]
     fn test_build_program_undefined_label_error() {
-        let mut ast = AST::new();
-
-        // Jump to undefined label
-        let inst = Instruction {
-            opcode: Opcode::Ja,
-            dst: None,
-            src: None,
-            off: Some(Either::Left("undefined_label".to_string())),
-            imm: None,
-            span: 0..10,
-        };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: inst,
-            offset: 0,
-        });
-        ast.set_text_size(8);
-
         for arch in [SbpfArch::V0, SbpfArch::V3] {
-            let result = ast.build_program(arch);
+            let mut ast = AST::new();
+            ast.nodes.push(instruction_node(
+                Opcode::Ja,
+                0,
+                Some(Either::Left("undefined_label".to_string())),
+                None,
+            ));
+            ast.set_text_size(8);
+
+            let result = build_program(ast, arch, OptimizationConfig::default());
             assert!(result.is_err());
         }
     }
@@ -427,36 +658,19 @@ mod tests {
     fn test_build_program_static_syscalls_no_relocation() {
         let mut ast = AST::new();
 
-        let syscall_inst = Instruction {
-            opcode: Opcode::Call,
-            dst: None,
-            src: None,
-            off: None,
-            imm: Some(Either::Left("sol_log_".to_string())),
-            span: 0..8,
-        };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: syscall_inst,
-            offset: 0,
-        });
-
-        let exit_inst = Instruction {
-            opcode: Opcode::Exit,
-            dst: None,
-            src: None,
-            off: None,
-            imm: None,
-            span: 8..16,
-        };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: exit_inst,
-            offset: 8,
-        });
+        ast.nodes.push(instruction_node(
+            Opcode::Call,
+            0,
+            None,
+            Some(Either::Left("sol_log_".to_string())),
+        ));
+        ast.nodes
+            .push(instruction_node(Opcode::Exit, 8, None, None));
 
         ast.set_text_size(16);
         ast.set_rodata_size(0);
 
-        let result = ast.build_program(SbpfArch::V3);
+        let result = build_program(ast, SbpfArch::V3, OptimizationConfig::default());
         assert!(result.is_ok());
         let parse_result = result.unwrap();
 
@@ -468,40 +682,66 @@ mod tests {
     fn test_build_program_dynamic_syscalls_with_relocation() {
         let mut ast = AST::new();
 
-        let syscall_inst = Instruction {
-            opcode: Opcode::Call,
-            dst: None,
-            src: None,
-            off: None,
-            imm: Some(Either::Left("sol_log_".to_string())),
-            span: 0..8,
-        };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: syscall_inst,
-            offset: 0,
-        });
-
-        let exit_inst = Instruction {
-            opcode: Opcode::Exit,
-            dst: None,
-            src: None,
-            off: None,
-            imm: None,
-            span: 8..16,
-        };
-        ast.nodes.push(ASTNode::Instruction {
-            instruction: exit_inst,
-            offset: 8,
-        });
+        ast.nodes.push(instruction_node(
+            Opcode::Call,
+            0,
+            None,
+            Some(Either::Left("sol_log_".to_string())),
+        ));
+        ast.nodes
+            .push(instruction_node(Opcode::Exit, 8, None, None));
 
         ast.set_text_size(16);
         ast.set_rodata_size(0);
 
-        let result = ast.build_program(SbpfArch::V0);
+        let result = build_program(ast, SbpfArch::V0, OptimizationConfig::default());
         assert!(result.is_ok());
         let parse_result = result.unwrap();
 
         assert!(!parse_result.prog_is_static);
         assert!(!parse_result.relocation_data.get_rel_dyns().is_empty());
+    }
+
+    fn label_node(name: &str, offset: u64) -> ASTNode {
+        ASTNode::Label {
+            label: Label {
+                name: name.to_string(),
+                span: 0..0,
+            },
+            offset,
+        }
+    }
+
+    fn instruction_node(
+        opcode: Opcode,
+        offset: u64,
+        off: Option<Either<String, i16>>,
+        imm: Option<Either<String, Number>>,
+    ) -> ASTNode {
+        ASTNode::Instruction {
+            instruction: Instruction {
+                opcode,
+                dst: None,
+                src: None,
+                off,
+                imm,
+                span: 0..0,
+            },
+            offset,
+        }
+    }
+
+    fn internal_call_node(offset: u64, relative_offset: i64) -> ASTNode {
+        ASTNode::Instruction {
+            instruction: Instruction {
+                opcode: Opcode::Call,
+                dst: None,
+                src: Some(Register { n: 1 }),
+                off: None,
+                imm: Some(Either::Right(Number::Int(relative_offset))),
+                span: 0..0,
+            },
+            offset,
+        }
     }
 }

--- a/crates/assembler/src/lib.rs
+++ b/crates/assembler/src/lib.rs
@@ -14,6 +14,7 @@ pub mod macros;
 pub mod ast;
 pub mod astnode;
 pub mod dynsym;
+pub mod optimizer;
 
 // ELF header, program, section
 pub mod header;
@@ -28,10 +29,11 @@ pub mod debug;
 pub mod wasm;
 
 pub use self::{
+    ast::OptimizationConfig,
     astnode::ASTNode,
     debug::DebugData,
     errors::CompileError,
-    parser::{ParseResult, Token, parse},
+    parser::{ProgramLayout, Token, parse, parse_with_optimization},
     preprocessor::{
         FileResolver, FsFileResolver, MockFileResolver, PreprocessResult, preprocess,
         source_map::{FileRegistry, SourceMap, SourceOrigin},
@@ -76,6 +78,8 @@ pub struct AssemblerOption {
     pub arch: SbpfArch,
     /// Optional debug mode configuration
     pub debug_mode: Option<DebugMode>,
+    /// Optional optimization and CFG diagnostic configuration
+    pub optimization: OptimizationConfig,
 }
 
 impl AssemblerOption {
@@ -138,7 +142,11 @@ impl Assembler {
     /// Assemble source code directly (no preprocessing).
     /// This is the original API -- macros and includes are not supported.
     pub fn assemble(&self, source: &str) -> Result<Vec<u8>, Vec<CompileError>> {
-        let parse_result = match parse(source, self.options.arch) {
+        let parse_result = match parse_with_optimization(
+            source,
+            self.options.arch,
+            self.options.optimization.clone(),
+        ) {
             Ok(result) => result,
             Err(errors) => {
                 return Err(errors);
@@ -196,7 +204,11 @@ impl Assembler {
         let source_map = &preprocess_result.source_map;
 
         // Parse the expanded source
-        let parse_result = match parse(expanded, self.options.arch) {
+        let parse_result = match parse_with_optimization(
+            expanded,
+            self.options.arch,
+            self.options.optimization.clone(),
+        ) {
             Ok(result) => result,
             Err(errors) => {
                 // Extract file registry from source map before moving errors
@@ -275,7 +287,7 @@ type LabelEntry = (String, u64, u32); // (label, offset, line)
 /// Helper function to collect line and label entries
 fn collect_line_and_label_entries(
     source: &str,
-    parse_result: &ParseResult,
+    parse_result: &ProgramLayout,
 ) -> (Vec<LineEntry>, Vec<LabelEntry>) {
     let mut files: Files<&str> = Files::new();
     let file_id = files.add("source", source);

--- a/crates/assembler/src/optimizer/canonicalize.rs
+++ b/crates/assembler/src/optimizer/canonicalize.rs
@@ -1,0 +1,290 @@
+use {
+    crate::{
+        CompileError,
+        ast::AST,
+        astnode::{ASTNode, Label},
+    },
+    either::Either,
+    sbpf_common::opcode::Opcode,
+    std::collections::{HashMap, HashSet},
+};
+
+const CONTROL_FLOW_TARGET_PREFIX: &str = "temp_";
+
+#[derive(Default)]
+pub(crate) struct CanonicalizedTargets {
+    pub(crate) labels_to_remove: HashSet<String>,
+    pub(crate) errors: Vec<CompileError>,
+}
+
+enum ControlFlowTarget {
+    Jump,
+    Call,
+}
+
+pub(crate) fn canonicalize_control_flow_targets(nodes: &mut Vec<ASTNode>) -> CanonicalizedTargets {
+    let mut label_at_offset = HashMap::new();
+    let mut existing_labels = HashSet::new();
+    let mut numeric_labels = Vec::new();
+    let mut valid_target_offsets = HashSet::new();
+
+    for (idx, node) in nodes.iter().enumerate() {
+        match node {
+            ASTNode::Label { label, offset } => {
+                label_at_offset
+                    .entry(*offset)
+                    .or_insert_with(|| label.name.clone());
+                existing_labels.insert(label.name.clone());
+                numeric_labels.push((label.name.clone(), *offset, idx));
+            }
+            ASTNode::Instruction { offset, .. } => {
+                valid_target_offsets.insert(*offset);
+            }
+            _ => {}
+        }
+    }
+
+    let mut rewrites = Vec::new();
+    let mut labels_to_insert_by_offset = HashMap::new();
+    let mut labels_to_remove = HashSet::new();
+    let mut errors = Vec::new();
+
+    for (idx, node) in nodes.iter().enumerate() {
+        let ASTNode::Instruction {
+            instruction,
+            offset,
+        } = node
+        else {
+            continue;
+        };
+
+        if instruction.is_jump() {
+            match &instruction.off {
+                Some(Either::Left(label)) => {
+                    if existing_labels.contains(label) {
+                        continue;
+                    }
+
+                    if let Some(target_offset) =
+                        AST::resolve_numeric_label(label, idx, &numeric_labels)
+                    {
+                        let canonical_label = canonical_label_for_target(
+                            target_offset,
+                            &mut label_at_offset,
+                            &mut existing_labels,
+                            &mut labels_to_insert_by_offset,
+                            &mut labels_to_remove,
+                        );
+                        rewrites.push((idx, ControlFlowTarget::Jump, canonical_label));
+                    }
+                }
+                Some(Either::Right(relative_offset)) => {
+                    let Some(target_offset) =
+                        relative_control_flow_target(*offset, *relative_offset as i64)
+                    else {
+                        errors.push(invalid_relative_target_error(
+                            "jump",
+                            *relative_offset as i64,
+                            None,
+                            &instruction.span,
+                        ));
+                        continue;
+                    };
+
+                    if !valid_target_offsets.contains(&target_offset) {
+                        errors.push(invalid_relative_target_error(
+                            "jump",
+                            *relative_offset as i64,
+                            Some(target_offset),
+                            &instruction.span,
+                        ));
+                        continue;
+                    }
+
+                    let canonical_label = canonical_label_for_target(
+                        target_offset,
+                        &mut label_at_offset,
+                        &mut existing_labels,
+                        &mut labels_to_insert_by_offset,
+                        &mut labels_to_remove,
+                    );
+                    rewrites.push((idx, ControlFlowTarget::Jump, canonical_label));
+                }
+                None => {}
+            }
+        } else if instruction.opcode == Opcode::Call
+            && instruction.src.as_ref().is_some_and(|src| src.n == 1)
+            && let Some(Either::Right(relative_offset)) = &instruction.imm
+        {
+            let relative_offset = relative_offset.to_i64();
+            let Some(target_offset) = relative_control_flow_target(*offset, relative_offset) else {
+                errors.push(invalid_relative_target_error(
+                    "call",
+                    relative_offset,
+                    None,
+                    &instruction.span,
+                ));
+                continue;
+            };
+
+            if !valid_target_offsets.contains(&target_offset) {
+                errors.push(invalid_relative_target_error(
+                    "call",
+                    relative_offset,
+                    Some(target_offset),
+                    &instruction.span,
+                ));
+                continue;
+            }
+
+            let canonical_label = canonical_label_for_target(
+                target_offset,
+                &mut label_at_offset,
+                &mut existing_labels,
+                &mut labels_to_insert_by_offset,
+                &mut labels_to_remove,
+            );
+            rewrites.push((idx, ControlFlowTarget::Call, canonical_label));
+        }
+    }
+
+    // Canonicalization is an optimization prerequisite, not additional bytecode
+    // validation. Leave the AST untouched when any target cannot be normalized.
+    if !errors.is_empty() {
+        return CanonicalizedTargets {
+            labels_to_remove: HashSet::new(),
+            errors,
+        };
+    }
+
+    for (idx, target_kind, canonical_label) in rewrites {
+        if let Some(ASTNode::Instruction { instruction, .. }) = nodes.get_mut(idx) {
+            match target_kind {
+                ControlFlowTarget::Jump => {
+                    instruction.off = Some(Either::Left(canonical_label));
+                }
+                ControlFlowTarget::Call => {
+                    instruction.imm = Some(Either::Left(canonical_label));
+                }
+            }
+        }
+    }
+
+    if !labels_to_insert_by_offset.is_empty() {
+        insert_temp_control_flow_target_labels(nodes, labels_to_insert_by_offset);
+    }
+
+    CanonicalizedTargets {
+        labels_to_remove,
+        errors,
+    }
+}
+
+fn canonical_label_for_target(
+    target_offset: u64,
+    label_at_offset: &mut HashMap<u64, String>,
+    existing_labels: &mut HashSet<String>,
+    labels_to_insert_by_offset: &mut HashMap<u64, Label>,
+    labels_to_remove: &mut HashSet<String>,
+) -> String {
+    if let Some(label) = label_at_offset.get(&target_offset) {
+        return label.clone();
+    }
+
+    labels_to_insert_by_offset
+        .entry(target_offset)
+        .or_insert_with(|| {
+            let label = Label {
+                name: next_temp_control_flow_target_label_name(target_offset, existing_labels),
+                span: 0..0,
+            };
+            existing_labels.insert(label.name.clone());
+            label_at_offset.insert(target_offset, label.name.clone());
+            labels_to_remove.insert(label.name.clone());
+            label
+        })
+        .name
+        .clone()
+}
+
+fn next_temp_control_flow_target_label_name(
+    offset: u64,
+    existing_labels: &HashSet<String>,
+) -> String {
+    let base = format!("{CONTROL_FLOW_TARGET_PREFIX}{offset}");
+    if !existing_labels.contains(&base) {
+        return base;
+    }
+
+    let mut suffix = 0;
+    loop {
+        let candidate = format!("{base}_{suffix}");
+        if !existing_labels.contains(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn relative_control_flow_target(offset: u64, relative_offset: i64) -> Option<u64> {
+    let offset = i64::try_from(offset).ok()?;
+    let displacement = relative_offset.checked_add(1)?.checked_mul(8)?;
+    let target_offset = offset.checked_add(displacement)?;
+    u64::try_from(target_offset).ok()
+}
+
+fn invalid_relative_target_error(
+    target_kind: &str,
+    relative_offset: i64,
+    target_offset: Option<u64>,
+    span: &std::ops::Range<usize>,
+) -> CompileError {
+    let error = if let Some(target_offset) = target_offset {
+        format!(
+            "Relative {target_kind} target {relative_offset:+} resolves to byte offset \
+             {target_offset}, which is not an instruction"
+        )
+    } else {
+        format!("Relative {target_kind} target {relative_offset:+} resolves outside the program")
+    };
+
+    CompileError::BytecodeError {
+        error,
+        span: span.clone(),
+        custom_label: None,
+    }
+}
+
+fn insert_temp_control_flow_target_labels(
+    nodes: &mut Vec<ASTNode>,
+    labels_by_offset: HashMap<u64, Label>,
+) {
+    let mut rewritten_nodes = Vec::with_capacity(nodes.len() + labels_by_offset.len());
+
+    for node in std::mem::take(nodes) {
+        if let ASTNode::Instruction { offset, .. } = &node
+            && let Some(label) = labels_by_offset.get(offset)
+        {
+            rewritten_nodes.push(ASTNode::Label {
+                label: label.clone(),
+                offset: *offset,
+            });
+        }
+        rewritten_nodes.push(node);
+    }
+
+    *nodes = rewritten_nodes;
+}
+
+pub(crate) fn remove_temp_control_flow_target_labels(
+    nodes: &mut Vec<ASTNode>,
+    labels_to_remove: &HashSet<String>,
+) {
+    if labels_to_remove.is_empty() {
+        return;
+    }
+
+    nodes.retain(|node| {
+        !matches!(node, ASTNode::Label { label, .. } if labels_to_remove.contains(&label.name))
+    });
+}

--- a/crates/assembler/src/optimizer/mod.rs
+++ b/crates/assembler/src/optimizer/mod.rs
@@ -1,0 +1,352 @@
+mod canonicalize;
+
+pub(crate) use canonicalize::{
+    canonicalize_control_flow_targets, remove_temp_control_flow_target_labels,
+};
+use {
+    crate::{ast::AST, astnode::ASTNode},
+    sbpf_ir::{Cfg, InputNode, control_flow_graph},
+    sbpf_transform::remove_dead_functions,
+    std::collections::HashSet,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CfgDumpStage {
+    BeforeDfe,
+    AfterDfe,
+}
+
+impl CfgDumpStage {
+    pub fn file_name(self) -> &'static str {
+        match self {
+            Self::BeforeDfe => "dfe-before.dot",
+            Self::AfterDfe => "dfe-after.dot",
+        }
+    }
+}
+
+/// Removes functions not reachable from the entry via `call imm`.
+pub fn eliminate_unreachable_functions(ast: &mut AST) {
+    eliminate_unreachable_functions_with_observer(ast, |_, _| {});
+}
+
+/// Removes unreachable functions and exposes the CFG before and after the pass.
+/// The observer owns any optional diagnostics or I/O, keeping the pass itself pure.
+pub fn eliminate_unreachable_functions_with_observer<F>(ast: &mut AST, mut observe: F)
+where
+    F: FnMut(CfgDumpStage, &Cfg),
+{
+    let mut cfg = cfg_for_ast(ast);
+    observe(CfgDumpStage::BeforeDfe, &cfg);
+
+    let removed_functions = remove_dead_functions(&mut cfg);
+
+    if !removed_functions.is_empty() {
+        let dead_node_ids: HashSet<usize> = removed_functions
+            .into_iter()
+            .flat_map(|f| f.node_ids)
+            .collect();
+        strip_dead_nodes(ast, &dead_node_ids);
+    }
+
+    assign_offsets(ast);
+
+    let cfg = cfg_for_ast(ast);
+    observe(CfgDumpStage::AfterDfe, &cfg);
+}
+
+/// Removes AST nodes belonging to dead functions, identified by their index in
+/// `ast.nodes`. Non-label/instruction nodes (e.g. `GlobalDecl`) are always kept.
+fn strip_dead_nodes(ast: &mut AST, dead_node_ids: &HashSet<usize>) {
+    ast.nodes = std::mem::take(&mut ast.nodes)
+        .into_iter()
+        .enumerate()
+        .filter(|(idx, node)| {
+            !matches!(node, ASTNode::Label { .. } | ASTNode::Instruction { .. })
+                || !dead_node_ids.contains(idx)
+        })
+        .map(|(_, node)| node)
+        .collect();
+}
+
+/// Recomputes byte offsets for all labels and instructions in the AST from
+/// scratch, in node order. Called after any pass that alters the node list so
+/// there is a single authoritative place that assigns offsets.
+pub fn assign_offsets(ast: &mut AST) {
+    let mut text_offset = 0u64;
+    let mut text_size = 0u64;
+    for node in &mut ast.nodes {
+        match node {
+            ASTNode::Label { offset, .. } => *offset = text_offset,
+            ASTNode::Instruction {
+                instruction,
+                offset,
+            } => {
+                *offset = text_offset;
+                let size = instruction.get_size();
+                text_offset += size;
+                text_size += size;
+            }
+            _ => {}
+        }
+    }
+    ast.set_text_size(text_size);
+}
+
+fn cfg_for_ast(ast: &AST) -> Cfg {
+    let function_entries = function_entries(ast);
+    let entry_label = ast.nodes.iter().find_map(|node| {
+        if let ASTNode::GlobalDecl { global_decl } = node {
+            Some(global_decl.entry_label.as_str())
+        } else {
+            None
+        }
+    });
+    let nodes = ast.nodes.iter().map(|node| match node {
+        ASTNode::Label { label, .. } => InputNode::Label(label.name.as_str()),
+        ASTNode::Instruction { instruction, .. } => InputNode::Instruction(instruction),
+        _ => InputNode::Other,
+    });
+    control_flow_graph(nodes, &function_entries, entry_label)
+}
+
+fn function_entries(ast: &AST) -> HashSet<String> {
+    ast.function_entries().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::astnode::{GlobalDecl, Label},
+        either::Either,
+        sbpf_common::{inst_param::Register, instruction::Instruction, opcode::Opcode},
+    };
+
+    #[test]
+    fn test_optimizer_preserves_unreachable_blocks_in_reachable_function() {
+        let mut ast = AST::new();
+        ast.add_function_entry("entrypoint".to_string());
+        ast.nodes = vec![
+            label_node("entrypoint", 0),
+            instruction_node(
+                Opcode::Ja,
+                None,
+                0,
+                Some(Either::Left("target".to_string())),
+            ),
+            instruction_node(Opcode::Mov64Imm, Some(0), 8, None),
+            label_node("target", 16),
+            instruction_node(Opcode::Exit, None, 16, None),
+        ];
+        ast.set_text_size(24);
+
+        eliminate_unreachable_functions(&mut ast);
+
+        assert_eq!(ast.nodes.len(), 5);
+        assert!(matches!(
+            &ast.nodes[1],
+            ASTNode::Instruction { instruction, offset }
+                if instruction.opcode == Opcode::Ja
+                    && instruction.off == Some(Either::Left("target".to_string()))
+                    && *offset == 0
+        ));
+        assert!(matches!(
+            &ast.nodes[2],
+            ASTNode::Instruction { instruction, offset }
+                if instruction.opcode == Opcode::Mov64Imm && *offset == 8
+        ));
+        assert!(matches!(
+            &ast.nodes[3],
+            ASTNode::Label { label, offset } if label.name == "target" && *offset == 16
+        ));
+        assert!(matches!(
+            &ast.nodes[4],
+            ASTNode::Instruction { instruction, offset }
+                if instruction.opcode == Opcode::Exit && *offset == 16
+        ));
+    }
+
+    #[test]
+    fn test_optimizer_removes_uncalled_function_only() {
+        let mut ast = AST::new();
+        ast.add_function_entry("entrypoint".to_string());
+        ast.add_function_entry("dead".to_string());
+        ast.add_function_entry("callee".to_string());
+        ast.nodes = vec![
+            label_node("entrypoint", 0),
+            call_node("callee", 0),
+            instruction_node(Opcode::Exit, None, 8, None),
+            label_node("dead", 16),
+            instruction_node(Opcode::Exit, None, 16, None),
+            label_node("callee", 24),
+            instruction_node(Opcode::Exit, None, 24, None),
+        ];
+        ast.set_text_size(32);
+
+        eliminate_unreachable_functions(&mut ast);
+
+        assert!(
+            !ast.nodes
+                .iter()
+                .any(|node| matches!(node, ASTNode::Label { label, .. } if label.name == "dead"))
+        );
+        assert!(
+            ast.nodes
+                .iter()
+                .any(|node| matches!(node, ASTNode::Label { label, offset }
+                if label.name == "callee" && *offset == 16))
+        );
+        assert_eq!(
+            ast.nodes
+                .iter()
+                .filter(|node| matches!(node, ASTNode::Instruction { .. }))
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn test_optimizer_uses_declared_entry_when_it_is_not_first() {
+        let mut ast = AST::new();
+        ast.add_function_entry("helper".to_string());
+        ast.add_function_entry("dead".to_string());
+        ast.add_function_entry("entrypoint".to_string());
+        ast.nodes = vec![
+            ASTNode::GlobalDecl {
+                global_decl: GlobalDecl {
+                    entry_label: "entrypoint".to_string(),
+                    span: 0..0,
+                },
+            },
+            label_node("helper", 0),
+            instruction_node(Opcode::Exit, None, 0, None),
+            label_node("dead", 8),
+            instruction_node(Opcode::Exit, None, 8, None),
+            label_node("entrypoint", 16),
+            call_node("helper", 16),
+            instruction_node(Opcode::Exit, None, 24, None),
+        ];
+        ast.set_text_size(32);
+
+        let cfg = cfg_for_ast(&ast);
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+        assert_eq!(cfg.functions()[0].entry_block_id(), Some(2)); // entrypoint is block 2 in source order
+
+        eliminate_unreachable_functions(&mut ast);
+
+        assert!(ast.nodes.iter().any(
+            |node| matches!(node, ASTNode::Label { label, .. } if label.name == "entrypoint")
+        ));
+        assert!(
+            ast.nodes
+                .iter()
+                .any(|node| matches!(node, ASTNode::Label { label, .. } if label.name == "helper"))
+        );
+        assert!(
+            !ast.nodes
+                .iter()
+                .any(|node| matches!(node, ASTNode::Label { label, .. } if label.name == "dead"))
+        );
+    }
+
+    #[test]
+    fn test_strip_dead_nodes_and_assign_offsets_recomputes_cumulatively() {
+        let mut ast = AST::new();
+        // node indices: 0=entrypoint, 1=exit, 2=dead_a, 3=exit, 4=live, 5=exit, 6=dead_b, 7=exit, 8=target, 9=exit
+        ast.nodes = vec![
+            label_node("entrypoint", 0),
+            instruction_node(Opcode::Exit, None, 0, None),
+            label_node("dead_a", 8),
+            instruction_node(Opcode::Exit, None, 8, None),
+            label_node("live", 16),
+            instruction_node(Opcode::Exit, None, 16, None),
+            label_node("dead_b", 24),
+            instruction_node(Opcode::Exit, None, 24, None),
+            label_node("target", 32),
+            instruction_node(Opcode::Exit, None, 32, None),
+        ];
+        ast.set_text_size(40);
+
+        strip_dead_nodes(&mut ast, &HashSet::from([2usize, 3, 6, 7]));
+        assign_offsets(&mut ast);
+
+        assert!(matches!(
+            &ast.nodes[2],
+            ASTNode::Label { label, offset } if label.name == "live" && *offset == 8
+        ));
+        assert!(matches!(
+            &ast.nodes[4],
+            ASTNode::Label { label, offset } if label.name == "target" && *offset == 16
+        ));
+    }
+
+    #[test]
+    fn test_assign_offsets_recomputes_from_scratch() {
+        let mut ast = AST::new();
+        ast.nodes = vec![
+            label_node("entrypoint", 999),
+            instruction_node(Opcode::Exit, None, 999, None),
+            label_node("next", 999),
+            instruction_node(Opcode::Exit, None, 999, None),
+        ];
+
+        assign_offsets(&mut ast);
+
+        assert!(matches!(
+            &ast.nodes[0],
+            ASTNode::Label { label, offset } if label.name == "entrypoint" && *offset == 0
+        ));
+        assert!(matches!(
+            &ast.nodes[1],
+            ASTNode::Instruction { offset, .. } if *offset == 0
+        ));
+        assert!(matches!(
+            &ast.nodes[2],
+            ASTNode::Label { label, offset } if label.name == "next" && *offset == 8
+        ));
+    }
+
+    fn label_node(name: &str, offset: u64) -> ASTNode {
+        ASTNode::Label {
+            label: Label {
+                name: name.to_string(),
+                span: 0..0,
+            },
+            offset,
+        }
+    }
+
+    fn instruction_node(
+        opcode: Opcode,
+        dst: Option<u8>,
+        offset: u64,
+        off: Option<Either<String, i16>>,
+    ) -> ASTNode {
+        ASTNode::Instruction {
+            instruction: Instruction {
+                opcode,
+                dst: dst.map(|n| Register { n }),
+                src: None,
+                off,
+                imm: None,
+                span: 0..0,
+            },
+            offset,
+        }
+    }
+
+    fn call_node(target: &str, offset: u64) -> ASTNode {
+        ASTNode::Instruction {
+            instruction: Instruction {
+                opcode: Opcode::Call,
+                dst: None,
+                src: None,
+                off: None,
+                imm: Some(Either::Left(target.to_string())),
+                span: 0..0,
+            },
+            offset,
+        }
+    }
+}

--- a/crates/assembler/src/parser/mod.rs
+++ b/crates/assembler/src/parser/mod.rs
@@ -6,7 +6,7 @@ mod llvm;
 use {
     crate::{
         SbpfArch,
-        ast::AST,
+        ast::{AST, OptimizationConfig, build_program},
         astnode::{ASTNode, Label},
         dynsym::{DynamicSymbolMap, RelDynMap},
         errors::CompileError,
@@ -62,7 +62,7 @@ pub enum Token {
     VectorLiteral(Vec<Number>, std::ops::Range<usize>),
 }
 
-pub struct ParseResult {
+pub struct ProgramLayout {
     // TODO: parse result is basically 1. static part 2. dynamic part of the program
     pub code_section: CodeSection,
 
@@ -82,7 +82,15 @@ pub struct ParseResult {
     pub debug_sections: Vec<DebugSection>,
 }
 
-pub fn parse(source: &str, arch: SbpfArch) -> Result<ParseResult, Vec<CompileError>> {
+pub fn parse(source: &str, arch: SbpfArch) -> Result<ProgramLayout, Vec<CompileError>> {
+    parse_with_optimization(source, arch, OptimizationConfig::default())
+}
+
+pub fn parse_with_optimization(
+    source: &str,
+    arch: SbpfArch,
+    optimization: OptimizationConfig,
+) -> Result<ProgramLayout, Vec<CompileError>> {
     let pairs = SbpfParser::parse(Rule::program, source).map_err(|e| {
         // Extract the actual byte position from the pest error so the source
         // map can resolve it back to the original file/line.
@@ -170,7 +178,7 @@ pub fn parse(source: &str, arch: SbpfArch) -> Result<ParseResult, Vec<CompileErr
     ast.set_text_size(text_offset);
     ast.set_rodata_size(rodata_offset);
 
-    ast.build_program(arch)
+    build_program(ast, arch, optimization)
 }
 
 /// Pass 1: lightweight scan of the parse tree to collect all label offsets.

--- a/crates/assembler/src/program.rs
+++ b/crates/assembler/src/program.rs
@@ -3,7 +3,7 @@ use {
         debug::{self, DebugData, reuse_debug_sections},
         dynsym::{DynamicSymbol, RelDyn, RelocationType},
         header::{ElfHeader, ProgramHeader},
-        parser::ParseResult,
+        parser::ProgramLayout,
         section::{
             DebugSection, DynStrSection, DynSymSection, DynamicSection, NullSection, RelDynSection,
             Section, SectionType, ShStrTabSection,
@@ -21,7 +21,7 @@ pub struct Program {
 
 impl Program {
     pub fn from_parse_result(
-        ParseResult {
+        ProgramLayout {
             code_section,
             data_section,
             dynamic_symbols,
@@ -29,7 +29,7 @@ impl Program {
             prog_is_static,
             arch,
             debug_sections,
-        }: ParseResult,
+        }: ProgramLayout,
         debug_data: Option<DebugData>,
     ) -> Self {
         let mut elf_header = ElfHeader::new();

--- a/crates/sbpf_ir/Cargo.toml
+++ b/crates/sbpf_ir/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sbpf-ir"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Intermediate representation and control-flow graph for SBPF programs"
+keywords = ["solana", "bpf", "ir", "cfg"]
+categories = ["development-tools", "compilers"]
+rust-version.workspace = true
+
+[lib]
+name = "sbpf_ir"
+
+[dependencies]
+either = { workspace = true }
+sbpf-common = { workspace = true }
+smallvec = { workspace = true }

--- a/crates/sbpf_ir/src/cfg.rs
+++ b/crates/sbpf_ir/src/cfg.rs
@@ -1,0 +1,651 @@
+use {
+    crate::{InstId, InstructionNode, InstructionVisitor, graph_engine::DfsGraph},
+    either::Either,
+    sbpf_common::{instruction::Instruction, opcode::Opcode},
+    smallvec::SmallVec,
+    std::collections::{HashMap, HashSet},
+};
+
+pub type BlockId = usize;
+pub type FunctionId = usize;
+
+#[derive(Debug, Clone, Copy)]
+pub enum InputNode<'a> {
+    Label(&'a str),
+    Instruction(&'a Instruction),
+    Other,
+}
+
+/// A basic block owning its instruction nodes.
+#[derive(Debug, Clone, Default)]
+pub struct Block {
+    pub node_ids: Vec<usize>,
+    pub labels: Vec<(String, usize)>,
+    pub instructions: Vec<InstructionNode>,
+}
+
+impl Block {
+    pub fn node_ids(&self) -> &[usize] {
+        &self.node_ids
+    }
+
+    pub fn labels(&self) -> &[(String, usize)] {
+        &self.labels
+    }
+
+    pub fn instructions(&self) -> &[InstructionNode] {
+        &self.instructions
+    }
+}
+
+/// A function in the CFG owning its basic blocks. `block_ids` stores the global
+/// `BlockId` of each owned block (parallel to `blocks`), so membership is explicit
+/// rather than inferred from a contiguous range.
+#[derive(Debug, Clone)]
+pub struct CfgFunction {
+    pub name: String,
+    /// Global BlockIds for each block in `blocks`, in order.
+    pub block_ids: Vec<BlockId>,
+    pub blocks: Vec<Block>,
+}
+
+impl CfgFunction {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn block_ids(&self) -> &[BlockId] {
+        &self.block_ids
+    }
+
+    pub fn blocks(&self) -> &[Block] {
+        &self.blocks
+    }
+
+    /// The global BlockId of this function's entry (first) block, if any.
+    pub fn entry_block_id(&self) -> Option<BlockId> {
+        self.block_ids.first().copied()
+    }
+}
+
+/// The control flow graph. Functions own their blocks, which own their instruction nodes.
+/// Removing a function automatically drops all its blocks and instructions via Rust ownership.
+#[derive(Debug, Clone, Default)]
+pub struct Cfg {
+    pub functions: Vec<CfgFunction>,
+    pub successors: Vec<SmallVec<[BlockId; 3]>>,
+    pub predecessors: Vec<SmallVec<[BlockId; 3]>>,
+}
+
+/// Builds a CFG in source order. If `entry_label` names a known function entry,
+/// that function is placed first in `functions()`.
+pub fn control_flow_graph<'a>(
+    nodes: impl IntoIterator<Item = InputNode<'a>>,
+    function_entries: &HashSet<String>,
+    entry_label: Option<&str>,
+) -> Cfg {
+    let flat_blocks = collect_blocks(nodes);
+    let n_blocks = flat_blocks.len();
+
+    let functions = collect_functions(flat_blocks, function_entries, entry_label);
+
+    let mut cfg = Cfg {
+        functions,
+        successors: vec![SmallVec::new(); n_blocks],
+        predecessors: vec![SmallVec::new(); n_blocks],
+    };
+
+    for (from, to) in collect_edges(&cfg) {
+        cfg.add_edge(from, to);
+    }
+
+    cfg
+}
+
+impl Cfg {
+    pub fn functions(&self) -> &[CfgFunction] {
+        &self.functions
+    }
+
+    /// Returns a block by its global BlockId.
+    pub fn block(&self, id: BlockId) -> Option<&Block> {
+        for func in &self.functions {
+            if let Some(pos) = func.block_ids.iter().position(|&b| b == id) {
+                return func.blocks.get(pos);
+            }
+        }
+        None
+    }
+
+    /// Returns the index of the function that owns the given block, or `None` if the
+    /// block is not found in any function.
+    pub fn function_of_block(&self, block_id: BlockId) -> Option<FunctionId> {
+        self.functions
+            .iter()
+            .position(|func| func.block_ids.contains(&block_id))
+    }
+
+    pub fn successors(&self, id: BlockId) -> &[BlockId] {
+        self.successors
+            .get(id)
+            .map(SmallVec::as_slice)
+            .unwrap_or_default()
+    }
+
+    pub fn predecessors(&self, id: BlockId) -> &[BlockId] {
+        self.predecessors
+            .get(id)
+            .map(SmallVec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Returns an instruction by its global `InstId` (sequential position across all blocks).
+    pub fn instruction(&self, inst_id: InstId) -> Option<&InstructionNode> {
+        let mut base = 0usize;
+        for (_, block) in self.all_blocks() {
+            let n = block.instructions.len();
+            if inst_id >= base && inst_id < base + n {
+                return block.instructions.get(inst_id - base);
+            }
+            base += n;
+        }
+        None
+    }
+
+    /// Returns the first global `InstId` for the given block (sum of instruction counts
+    /// of all preceding blocks in traversal order).
+    pub fn block_inst_offset(&self, target_id: BlockId) -> usize {
+        let mut base = 0usize;
+        for (block_id, block) in self.all_blocks() {
+            if block_id == target_id {
+                return base;
+            }
+            base += block.instructions.len();
+        }
+        base
+    }
+
+    /// Iterates all (BlockId, &Block) pairs across all functions in order.
+    pub fn all_blocks(&self) -> impl Iterator<Item = (BlockId, &Block)> {
+        self.functions
+            .iter()
+            .flat_map(|f| f.block_ids.iter().copied().zip(f.blocks.iter()))
+    }
+
+    /// Iterates all (InstId, &InstructionNode) pairs across all blocks in order.
+    pub fn all_instructions(&self) -> impl Iterator<Item = (InstId, &InstructionNode)> {
+        self.all_blocks_with_inst_base()
+            .flat_map(|(base, _, block)| {
+                block
+                    .instructions
+                    .iter()
+                    .enumerate()
+                    .map(move |(i, node)| (base + i, node))
+            })
+    }
+
+    /// Total number of blocks across all functions.
+    pub fn total_blocks(&self) -> usize {
+        self.functions.iter().map(|f| f.blocks.len()).sum()
+    }
+
+    /// Total number of instructions across all blocks.
+    pub fn total_instructions(&self) -> usize {
+        self.functions
+            .iter()
+            .flat_map(|f| f.blocks.iter())
+            .map(|b| b.instructions.len())
+            .sum()
+    }
+
+    /// Internal: iterator of (inst_base, BlockId, &Block) with pre-computed inst offset.
+    fn all_blocks_with_inst_base(&self) -> impl Iterator<Item = (usize, BlockId, &Block)> {
+        let mut base = 0usize;
+        self.all_blocks().map(move |(id, block)| {
+            let b = base;
+            base += block.instructions.len();
+            (b, id, block)
+        })
+    }
+
+    fn add_edge(&mut self, from: BlockId, to: BlockId) {
+        if let Some(successors) = self.successors.get_mut(from)
+            && !successors.contains(&to)
+        {
+            successors.push(to);
+        }
+
+        if let Some(predecessors) = self.predecessors.get_mut(to)
+            && !predecessors.contains(&from)
+        {
+            predecessors.push(from);
+        }
+    }
+}
+
+/// Groups flat blocks into CfgFunctions. Each block receives the global BlockId equal
+/// to its position in the original flat list. A block starts a new function when one
+/// of its labels appears in `function_entries`. If `entry_label` names a known function
+/// entry, that function is moved to position 0 so `functions()[0]` is always the root.
+fn collect_functions(
+    blocks: Vec<Block>,
+    function_entries: &HashSet<String>,
+    entry_label: Option<&str>,
+) -> Vec<CfgFunction> {
+    if blocks.is_empty() {
+        return Vec::new();
+    }
+
+    // No function metadata: wrap everything in a single implicit root function.
+    if function_entries.is_empty() {
+        let n = blocks.len();
+        return vec![CfgFunction {
+            name: String::new(),
+            block_ids: (0..n).collect(),
+            blocks,
+        }];
+    }
+
+    let mut functions: Vec<CfgFunction> = Vec::new();
+
+    for (block_id, block) in blocks.into_iter().enumerate() {
+        // A block with a function-entry label starts a new function.
+        let func_name = block
+            .labels
+            .iter()
+            .find(|(label, _)| function_entries.contains(label.as_str()))
+            .map(|(label, _)| label.clone());
+
+        if let Some(name) = func_name {
+            // Case 1: function-entry label → start a new function.
+            // The entry block goes in first so entry_block_id() always returns the real entry.
+            let mut function = CfgFunction {
+                name,
+                block_ids: Vec::new(),
+                blocks: Vec::new(),
+            };
+            function.block_ids.push(block_id);
+            function.blocks.push(block);
+            functions.push(function);
+        } else if let Some(func) = functions.last_mut() {
+            // Case 2: continuation block — append to the current function.
+            func.block_ids.push(block_id);
+            func.blocks.push(block);
+        } else {
+            // Case 3: block before any function entry — not valid in the linker workflow.
+            unreachable!("block {block_id} appears before any function-entry label");
+        }
+    }
+
+    assert!(
+        !functions.is_empty(),
+        "no function-entry labels found in non-empty block list"
+    );
+
+    // Place the declared entry function first so functions()[0] is always the root.
+    if let Some(entry_label) = entry_label
+        && let Some(pos) = functions.iter().position(|f| f.name == entry_label)
+    {
+        functions[0..=pos].rotate_right(1);
+    }
+
+    functions
+}
+
+impl DfsGraph for Cfg {
+    type Node = BlockId;
+
+    fn successors(&self, node: Self::Node) -> &[Self::Node] {
+        self.successors(node)
+    }
+}
+
+fn collect_blocks<'a>(nodes: impl IntoIterator<Item = InputNode<'a>>) -> Vec<Block> {
+    let mut collector = BlockCollector::default();
+    for (node_id, node) in nodes.into_iter().enumerate() {
+        match node {
+            InputNode::Label(label) => collector.on_label(node_id, label),
+            InputNode::Instruction(instruction) => collector.on_instruction(node_id, instruction),
+            InputNode::Other => {}
+        }
+    }
+    collector.finish()
+}
+
+#[derive(Default)]
+struct BlockCollector {
+    blocks: Vec<Block>,
+    current: Block,
+}
+
+impl BlockCollector {
+    fn finish(mut self) -> Vec<Block> {
+        assert!(
+            self.current.labels.is_empty() || !self.current.instructions.is_empty(),
+            "trailing label(s) {:?} have no instructions",
+            self.current
+                .labels
+                .iter()
+                .map(|(l, _)| l)
+                .collect::<Vec<_>>()
+        );
+        if !self.current.instructions.is_empty() {
+            self.push_current_block();
+        }
+        self.blocks
+    }
+
+    fn push_current_block(&mut self) {
+        self.blocks.push(std::mem::take(&mut self.current));
+    }
+}
+
+impl BlockCollector {
+    fn on_label(&mut self, node_id: usize, label: &str) {
+        if !self.current.instructions.is_empty() {
+            self.push_current_block();
+        }
+        self.current.node_ids.push(node_id);
+        self.current.labels.push((label.to_string(), node_id));
+    }
+
+    fn on_instruction(&mut self, node_id: usize, instruction: &Instruction) {
+        self.current.node_ids.push(node_id);
+        let node = InstructionNode::from_instruction(node_id, instruction.clone());
+        self.current.instructions.push(node);
+
+        if instruction.opcode == Opcode::Exit || instruction.is_jump() {
+            self.push_current_block();
+        }
+    }
+}
+
+/// Collects CFG edges. Jump and call targets are always canonicalized to label names
+/// by the assembler (via `canonicalize_control_flow_targets`) before CFG construction,
+/// so only label-based lookups are needed.
+fn collect_edges(cfg: &Cfg) -> Vec<(BlockId, BlockId)> {
+    let label_to_block = label_to_block_map(cfg);
+    let block_count = cfg.successors.len();
+
+    let mut collector = EdgeCollector {
+        cfg,
+        label_to_block: &label_to_block,
+        block_count,
+        current_block: None,
+        edges: Vec::new(),
+    };
+
+    for (block_id, block) in cfg.all_blocks() {
+        collector.visit_block(block_id, block);
+    }
+    collector.edges
+}
+
+struct EdgeCollector<'a> {
+    cfg: &'a Cfg,
+    label_to_block: &'a HashMap<String, BlockId>,
+    block_count: usize,
+    current_block: Option<BlockId>,
+    edges: Vec<(BlockId, BlockId)>,
+}
+
+impl EdgeCollector<'_> {
+    fn add_edge(&mut self, to: BlockId) {
+        if let Some(from) = self.current_block {
+            self.edges.push((from, to));
+        }
+    }
+
+    fn add_fallthrough_edge(&mut self) {
+        let Some(block_id) = self.current_block else {
+            return;
+        };
+        let next = block_id + 1;
+        if next >= self.block_count {
+            return;
+        }
+        // Suppress fall-through across function boundaries: the only valid way
+        // to enter a function is via an explicit `call imm` instruction.
+        let same_function = match (
+            self.cfg.function_of_block(block_id),
+            self.cfg.function_of_block(next),
+        ) {
+            (Some(f1), Some(f2)) => f1 == f2,
+            _ => true,
+        };
+        if same_function {
+            self.edges.push((block_id, next));
+        }
+    }
+}
+
+impl EdgeCollector<'_> {
+    fn visit_block(&mut self, block_id: BlockId, block: &Block) {
+        self.current_block = Some(block_id);
+
+        for node in block.instructions() {
+            self.visit_instruction_node(node);
+        }
+
+        let Some(last_node) = block.instructions().last() else {
+            return;
+        };
+        let Some(last_instruction) = last_node.instruction() else {
+            return;
+        };
+
+        if last_instruction.opcode == Opcode::Exit {
+            return;
+        }
+
+        if !last_instruction.is_jump() {
+            self.add_fallthrough_edge();
+        }
+    }
+}
+
+impl InstructionVisitor for EdgeCollector<'_> {
+    fn visit_call(&mut self, _node: &InstructionNode, instruction: &Instruction) {
+        if let Some(Either::Left(label)) = &instruction.imm
+            && let Some(&target) = self.label_to_block.get(label.as_str())
+        {
+            self.add_edge(target);
+        }
+    }
+
+    fn visit_jump(&mut self, _node: &InstructionNode, instruction: &Instruction) {
+        if let Some(Either::Left(label)) = &instruction.off
+            && let Some(&target) = self.label_to_block.get(label.as_str())
+        {
+            self.add_edge(target);
+        }
+        if instruction.opcode != Opcode::Ja {
+            self.add_fallthrough_edge();
+        }
+    }
+}
+
+fn label_to_block_map(cfg: &Cfg) -> HashMap<String, BlockId> {
+    cfg.all_blocks()
+        .flat_map(|(block_id, block)| {
+            block
+                .labels
+                .iter()
+                .map(move |(label, _)| (label.clone(), block_id))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::graph_engine::{DfsEngine, WorklistEngine},
+        either::Either,
+        sbpf_common::{inst_param::Register, instruction::Instruction},
+    };
+
+    #[test]
+    fn test_cfg_dfs_visits_blocks() {
+        let cfg = test_cfg();
+        let mut visited = Vec::new();
+
+        DfsEngine::new(&cfg).visit(0, &mut |block| visited.push(block));
+
+        assert_eq!(visited, vec![0, 2]);
+        assert_eq!(cfg.total_blocks(), 3);
+        assert_eq!(cfg.block(2).unwrap().labels()[0].0, "target");
+    }
+
+    #[test]
+    fn test_cfg_worklist_visits_blocks() {
+        let cfg = test_cfg();
+        let mut visited = Vec::new();
+
+        WorklistEngine::new(&cfg)
+            .initialize([0])
+            .run(&mut |block| visited.push(block));
+
+        assert_eq!(visited, vec![0, 2]);
+    }
+
+    #[test]
+    fn test_cfg_groups_blocks_by_function_entries() {
+        let entry_jump = instruction(Opcode::Ja, Some(Either::Left("internal".to_string())));
+        let internal_exit = instruction(Opcode::Exit, None);
+        let helper_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&entry_jump),
+            InputNode::Label("internal"),
+            InputNode::Instruction(&internal_exit),
+            InputNode::Label("helper"),
+            InputNode::Instruction(&helper_exit),
+        ];
+        let function_entries = HashSet::from(["entrypoint".to_string(), "helper".to_string()]);
+
+        let cfg = control_flow_graph(nodes, &function_entries, None);
+
+        assert_eq!(cfg.functions().len(), 2);
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+        assert_eq!(cfg.functions()[0].blocks().len(), 2);
+        assert_eq!(cfg.functions()[0].block_ids(), &[0, 1]);
+        assert_eq!(cfg.functions()[1].name(), "helper");
+        assert_eq!(cfg.functions()[1].blocks().len(), 1);
+        assert_eq!(cfg.functions()[1].block_ids(), &[2]);
+    }
+
+    #[test]
+    fn test_cfg_places_declared_entry_function_first() {
+        // Source order: helper (block 0) then entrypoint (block 1).
+        // The declared entry should appear first in functions() despite coming second in source.
+        let helper_exit = instruction(Opcode::Exit, None);
+        let call_helper = Instruction {
+            opcode: Opcode::Call,
+            dst: None,
+            src: Some(Register { n: 1 }),
+            off: None,
+            imm: Some(Either::Left("helper".to_string())),
+            span: 0..0,
+        };
+        let entry_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("helper"),
+            InputNode::Instruction(&helper_exit),
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&call_helper),
+            InputNode::Instruction(&entry_exit),
+        ];
+        let function_entries = HashSet::from(["helper".to_string(), "entrypoint".to_string()]);
+
+        let cfg = control_flow_graph(nodes, &function_entries, Some("entrypoint"));
+
+        assert_eq!(cfg.functions()[0].name(), "entrypoint");
+        assert_eq!(cfg.functions()[0].entry_block_id(), Some(1)); // entrypoint is block 1 in source order
+        assert_eq!(cfg.block(1).unwrap().labels()[0].0, "entrypoint");
+        assert_eq!(cfg.functions()[1].name(), "helper");
+        assert_eq!(cfg.successors(1), &[0]); // entrypoint calls helper (block 0)
+    }
+
+    #[test]
+    fn test_cfg_groups_labels_with_following_instructions() {
+        let call = Instruction {
+            opcode: Opcode::Call,
+            dst: None,
+            src: Some(Register { n: 1 }),
+            off: None,
+            imm: Some(Either::Left("panic".to_string())),
+            span: 0..0,
+        };
+        let dead_exit = instruction(Opcode::Exit, None);
+        let panic_exit = instruction(Opcode::Exit, None);
+        // Source order: each label immediately precedes its instructions.
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&call),
+            InputNode::Label("dead_function"),
+            InputNode::Instruction(&dead_exit),
+            InputNode::Label("panic"),
+            InputNode::Instruction(&panic_exit),
+        ];
+        let cfg = control_flow_graph(nodes, &HashSet::new(), None);
+
+        assert_eq!(cfg.total_blocks(), 3);
+        assert_eq!(cfg.block(0).unwrap().node_ids(), &[0, 1]);
+        assert_eq!(cfg.block(1).unwrap().node_ids(), &[2, 3]);
+        assert_eq!(cfg.block(2).unwrap().node_ids(), &[4, 5]);
+        assert_eq!(cfg.successors(0), &[2, 1]);
+        assert!(cfg.successors(1).is_empty());
+        assert!(cfg.successors(2).is_empty());
+    }
+
+    #[test]
+    fn test_cfg_fallthrough_does_not_cross_function_boundary() {
+        let nop = instruction_with_registers(Opcode::Mov64Imm, Some(0), None, None);
+        let exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("func_a"),
+            InputNode::Instruction(&nop),
+            InputNode::Label("func_b"),
+            InputNode::Instruction(&exit),
+        ];
+        let function_entries = HashSet::from(["func_a".to_string(), "func_b".to_string()]);
+        let cfg = control_flow_graph(nodes, &function_entries, None);
+
+        assert!(cfg.successors(0).is_empty());
+    }
+
+    fn test_cfg() -> Cfg {
+        let jump = instruction(Opcode::Ja, Some(Either::Left("target".to_string())));
+        let dead_exit = instruction(Opcode::Exit, None);
+        let target_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&jump),
+            InputNode::Instruction(&dead_exit),
+            InputNode::Label("target"),
+            InputNode::Instruction(&target_exit),
+        ];
+        control_flow_graph(nodes, &HashSet::new(), None)
+    }
+
+    fn instruction(opcode: Opcode, off: Option<Either<String, i16>>) -> Instruction {
+        instruction_with_registers(opcode, None, None, off)
+    }
+
+    fn instruction_with_registers(
+        opcode: Opcode,
+        dst: Option<u8>,
+        src: Option<u8>,
+        off: Option<Either<String, i16>>,
+    ) -> Instruction {
+        Instruction {
+            opcode,
+            dst: dst.map(|n| Register { n }),
+            src: src.map(|n| Register { n }),
+            off,
+            imm: None,
+            span: 0..0,
+        }
+    }
+}

--- a/crates/sbpf_ir/src/dataflow.rs
+++ b/crates/sbpf_ir/src/dataflow.rs
@@ -1,0 +1,140 @@
+use sbpf_common::{instruction::Instruction, opcode::Opcode};
+
+pub type InstId = usize;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstructionNode {
+    pub opcode: Opcode,
+    source_node_id: Option<usize>,
+    instruction: Option<Instruction>,
+}
+
+impl InstructionNode {
+    pub fn new(opcode: Opcode) -> Self {
+        Self {
+            opcode,
+            source_node_id: None,
+            instruction: None,
+        }
+    }
+
+    pub fn from_instruction(source_node_id: usize, instruction: Instruction) -> Self {
+        Self {
+            opcode: instruction.opcode,
+            source_node_id: Some(source_node_id),
+            instruction: Some(instruction),
+        }
+    }
+
+    pub fn source_node_id(&self) -> Option<usize> {
+        self.source_node_id
+    }
+
+    pub fn instruction(&self) -> Option<&Instruction> {
+        self.instruction.as_ref()
+    }
+}
+
+pub trait InstructionVisitor {
+    fn visit_instruction_node(&mut self, node: &InstructionNode) {
+        walk_instruction_node(self, node);
+    }
+
+    fn visit_call(&mut self, node: &InstructionNode, _instruction: &Instruction) {
+        self.visit_default(node);
+    }
+
+    fn visit_jump(&mut self, node: &InstructionNode, _instruction: &Instruction) {
+        self.visit_default(node);
+    }
+
+    fn visit_default(&mut self, _node: &InstructionNode) {}
+}
+
+pub fn walk_instruction_nodes<'a, I, V>(visitor: &mut V, nodes: I)
+where
+    I: IntoIterator<Item = &'a InstructionNode>,
+    V: InstructionVisitor + ?Sized,
+{
+    for node in nodes {
+        visitor.visit_instruction_node(node);
+    }
+}
+
+pub fn walk_instruction_node<V>(visitor: &mut V, node: &InstructionNode)
+where
+    V: InstructionVisitor + ?Sized,
+{
+    let Some(instruction) = node.instruction() else {
+        visitor.visit_default(node);
+        return;
+    };
+
+    if instruction.opcode == Opcode::Call {
+        visitor.visit_call(node, instruction);
+    } else if instruction.is_jump() {
+        visitor.visit_jump(node, instruction);
+    } else {
+        visitor.visit_default(node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, sbpf_common::instruction::Instruction};
+
+    #[test]
+    fn test_dataflow_instruction_node_tracks_source() {
+        let instruction = instruction(Opcode::Exit);
+        let node = InstructionNode::from_instruction(7, instruction.clone());
+
+        assert_eq!(node.opcode, Opcode::Exit);
+        assert_eq!(node.source_node_id(), Some(7));
+        assert_eq!(node.instruction(), Some(&instruction));
+    }
+
+    #[test]
+    fn test_dataflow_visitor_dispatches_instruction_kinds() {
+        struct Visitor {
+            events: Vec<String>,
+        }
+
+        impl InstructionVisitor for Visitor {
+            fn visit_call(&mut self, node: &InstructionNode, _instruction: &Instruction) {
+                self.events
+                    .push(format!("call:{}", node.source_node_id().unwrap()));
+            }
+
+            fn visit_jump(&mut self, node: &InstructionNode, _instruction: &Instruction) {
+                self.events
+                    .push(format!("jump:{}", node.source_node_id().unwrap()));
+            }
+
+            fn visit_default(&mut self, node: &InstructionNode) {
+                self.events.push(format!("default:{}", node.opcode));
+            }
+        }
+
+        let mut visitor = Visitor { events: Vec::new() };
+        let call = InstructionNode::from_instruction(1, instruction(Opcode::Call));
+        let jump = InstructionNode::from_instruction(2, instruction(Opcode::Ja));
+        let exit = InstructionNode::from_instruction(3, instruction(Opcode::Exit));
+
+        visitor.visit_instruction_node(&call);
+        visitor.visit_instruction_node(&jump);
+        visitor.visit_instruction_node(&exit);
+
+        assert_eq!(visitor.events, vec!["call:1", "jump:2", "default:exit"]);
+    }
+
+    fn instruction(opcode: Opcode) -> Instruction {
+        Instruction {
+            opcode,
+            dst: None,
+            src: None,
+            off: None,
+            imm: None,
+            span: 0..0,
+        }
+    }
+}

--- a/crates/sbpf_ir/src/graph_engine/dfs.rs
+++ b/crates/sbpf_ir/src/graph_engine/dfs.rs
@@ -1,0 +1,94 @@
+//! Depth-first graph traversal.
+
+use std::{collections::HashSet, hash::Hash};
+
+pub trait DfsGraph {
+    type Node: Copy + Eq + Hash;
+
+    fn successors(&self, node: Self::Node) -> &[Self::Node];
+}
+
+/// Visitor called for each node during a DFS traversal.
+pub trait DfsVisitor<N> {
+    fn visit(&mut self, node: N);
+}
+
+/// Blanket impl so that a plain `FnMut(N)` closure works as a visitor.
+impl<N, F: FnMut(N)> DfsVisitor<N> for F {
+    fn visit(&mut self, node: N) {
+        self(node);
+    }
+}
+
+pub struct DfsEngine<'a, G> {
+    graph: &'a G,
+}
+
+impl<'a, G> DfsEngine<'a, G>
+where
+    G: DfsGraph,
+{
+    pub fn new(graph: &'a G) -> Self {
+        Self { graph }
+    }
+
+    pub fn visit<V>(&self, start: G::Node, visitor: &mut V)
+    where
+        V: DfsVisitor<G::Node>,
+    {
+        self.visit_many([start], visitor);
+    }
+
+    pub fn visit_many<I, V>(&self, starts: I, visitor: &mut V)
+    where
+        I: IntoIterator<Item = G::Node>,
+        V: DfsVisitor<G::Node>,
+    {
+        let mut visited = HashSet::new();
+        let mut stack = starts.into_iter().collect::<Vec<_>>();
+
+        while let Some(node) = stack.pop() {
+            if !visited.insert(node) {
+                continue;
+            }
+
+            visitor.visit(node);
+
+            for successor in self.graph.successors(node).iter().rev() {
+                stack.push(*successor);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestGraph {
+        successors: Vec<Vec<usize>>,
+    }
+
+    impl DfsGraph for TestGraph {
+        type Node = usize;
+
+        fn successors(&self, node: Self::Node) -> &[Self::Node] {
+            self.successors
+                .get(node)
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+        }
+    }
+
+    #[test]
+    fn test_dfs_visit() {
+        let graph = TestGraph {
+            successors: vec![vec![1, 2], vec![3], vec![3], vec![]],
+        };
+        let mut visited = Vec::new();
+
+        DfsEngine::new(&graph).visit(0, &mut |node| visited.push(node));
+
+        assert_eq!(visited, vec![0, 1, 3, 2]);
+    }
+}

--- a/crates/sbpf_ir/src/graph_engine/mod.rs
+++ b/crates/sbpf_ir/src/graph_engine/mod.rs
@@ -1,0 +1,9 @@
+//! Generic traversal and fixed-point iteration engines used by SBPF IR.
+
+pub mod dfs;
+pub mod worklist;
+
+pub use {
+    dfs::{DfsEngine, DfsGraph, DfsVisitor},
+    worklist::{Analysis, WorklistEngine, WorklistVisitor, fixed_point_analyze},
+};

--- a/crates/sbpf_ir/src/graph_engine/worklist.rs
+++ b/crates/sbpf_ir/src/graph_engine/worklist.rs
@@ -1,0 +1,294 @@
+//! Worklist traversal and fixed-point analysis.
+
+use {
+    crate::graph_engine::dfs::DfsGraph,
+    std::collections::{HashMap, HashSet, VecDeque},
+};
+
+/// Visitor called for each node during a worklist traversal.
+///
+/// The `enqueue` callback lets the visitor inject additional nodes that are not
+/// direct graph successors — for example, when discovering a new callee function
+/// and wanting to add *all* of its blocks rather than just the one reachable via
+/// a CFG edge.
+pub trait WorklistVisitor<N> {
+    fn visit(&mut self, node: N, enqueue: &mut dyn FnMut(N));
+}
+
+/// Blanket impl so that a plain `FnMut(N)` closure works as a visitor when no
+/// extra enqueueing is needed.
+impl<N, F: FnMut(N)> WorklistVisitor<N> for F {
+    fn visit(&mut self, node: N, _enqueue: &mut dyn FnMut(N)) {
+        self(node);
+    }
+}
+
+/// Stateful BFS worklist engine.
+///
+/// Usage pattern:
+/// ```ignore
+/// let mut engine = WorklistEngine::new(graph);
+/// engine.initialize(seeds);
+/// engine.run(&mut visitor);
+/// let visited = engine.visited();
+/// ```
+pub struct WorklistEngine<'a, G: DfsGraph> {
+    graph: &'a G,
+    pending: HashSet<G::Node>,
+    worklist: VecDeque<G::Node>,
+    visited: HashSet<G::Node>,
+}
+
+impl<'a, G: DfsGraph> WorklistEngine<'a, G> {
+    pub fn new(graph: &'a G) -> Self {
+        Self {
+            graph,
+            pending: HashSet::new(),
+            worklist: VecDeque::new(),
+            visited: HashSet::new(),
+        }
+    }
+
+    /// Seed the worklist with an initial set of nodes.
+    pub fn initialize(&mut self, items: impl IntoIterator<Item = G::Node>) -> &mut Self {
+        for item in items {
+            self.enqueue(item);
+        }
+        self
+    }
+
+    /// Add a single node to the worklist. No-op if already visited or pending.
+    pub fn enqueue(&mut self, item: G::Node) -> &mut Self {
+        if !self.visited.contains(&item) && self.pending.insert(item) {
+            self.worklist.push_back(item);
+        }
+        self
+    }
+
+    /// Process the worklist until empty.
+    ///
+    /// For each dequeued node, the visitor is called with `(node, enqueue)`.
+    /// After the visitor returns, all direct graph successors are also enqueued.
+    /// The `enqueue` callback lets the visitor inject additional nodes beyond
+    /// those covered by graph edges.
+    pub fn run<V: WorklistVisitor<G::Node>>(&mut self, visitor: &mut V) {
+        while let Some(node) = self.worklist.pop_front() {
+            self.pending.remove(&node);
+            if !self.visited.insert(node) {
+                continue;
+            }
+
+            // Collect any extra nodes the visitor wants to enqueue.
+            let mut extra = Vec::new();
+            visitor.visit(node, &mut |item| extra.push(item));
+
+            // Enqueue direct graph successors.
+            for &successor in self.graph.successors(node) {
+                if !self.visited.contains(&successor) && self.pending.insert(successor) {
+                    self.worklist.push_back(successor);
+                }
+            }
+            // Enqueue visitor-requested extras.
+            for item in extra {
+                if !self.visited.contains(&item) && self.pending.insert(item) {
+                    self.worklist.push_back(item);
+                }
+            }
+        }
+    }
+
+    /// Returns the set of nodes visited since construction (or last reset).
+    pub fn visited(&self) -> &HashSet<G::Node> {
+        &self.visited
+    }
+}
+
+// ── Fixed-point analysis ─────────────────────────────────────────────────────
+
+/// Lattice-based fixed-point analysis over a graph.
+pub trait Analysis<N> {
+    type State: Clone + PartialEq;
+
+    fn transfer(&mut self, node: N, state: &Self::State) -> Self::State;
+
+    fn join(&self, a: &Self::State, b: &Self::State) -> Self::State;
+}
+
+/// Run a fixed-point analysis from multiple start nodes, iterating until the
+/// per-node state stops changing.
+pub fn fixed_point_analyze<G, I, A>(
+    graph: &G,
+    starts: I,
+    initial_state: A::State,
+    analysis: &mut A,
+) -> HashMap<G::Node, A::State>
+where
+    G: DfsGraph,
+    I: IntoIterator<Item = G::Node>,
+    A: Analysis<G::Node>,
+{
+    let mut states: HashMap<G::Node, A::State> = HashMap::new();
+    let mut pending: HashSet<G::Node> = HashSet::new();
+    let mut worklist: VecDeque<G::Node> = VecDeque::new();
+
+    for node in starts {
+        states.insert(node, initial_state.clone());
+        if pending.insert(node) {
+            worklist.push_back(node);
+        }
+    }
+
+    while let Some(node) = worklist.pop_front() {
+        pending.remove(&node);
+
+        let Some(input_state) = states.get(&node).cloned() else {
+            continue;
+        };
+        let output_state = analysis.transfer(node, &input_state);
+
+        for successor in graph.successors(node) {
+            let next_state = states
+                .get(successor)
+                .map(|state| analysis.join(state, &output_state))
+                .unwrap_or_else(|| output_state.clone());
+
+            if states.get(successor) != Some(&next_state) {
+                states.insert(*successor, next_state);
+                if pending.insert(*successor) {
+                    worklist.push_back(*successor);
+                }
+            }
+        }
+    }
+
+    states
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::graph_engine::dfs::DfsGraph};
+
+    struct TestGraph {
+        successors: Vec<Vec<usize>>,
+    }
+
+    impl DfsGraph for TestGraph {
+        type Node = usize;
+
+        fn successors(&self, node: Self::Node) -> &[Self::Node] {
+            self.successors
+                .get(node)
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+        }
+    }
+
+    #[test]
+    fn test_worklist_visit_uses_fifo_order() {
+        let graph = TestGraph {
+            successors: vec![vec![1, 2], vec![3], vec![3], vec![]],
+        };
+        let mut visited = Vec::new();
+
+        WorklistEngine::new(&graph)
+            .initialize([0])
+            .run(&mut |node| visited.push(node));
+
+        assert_eq!(visited, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_worklist_visit_suppresses_duplicates() {
+        let graph = TestGraph {
+            successors: vec![vec![1, 1], vec![]],
+        };
+        let mut visited = Vec::new();
+
+        WorklistEngine::new(&graph)
+            .initialize([0, 0])
+            .run(&mut |node| visited.push(node));
+
+        assert_eq!(visited, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_worklist_enqueue_adds_extra_nodes() {
+        // Graph: 0 -> 1. Visitor on block 0 also enqueues block 2 (not a graph successor).
+        let graph = TestGraph {
+            successors: vec![vec![1], vec![], vec![]],
+        };
+
+        struct FanOutVisitor(Vec<usize>);
+        impl WorklistVisitor<usize> for FanOutVisitor {
+            fn visit(&mut self, node: usize, enqueue: &mut dyn FnMut(usize)) {
+                self.0.push(node);
+                if node == 0 {
+                    enqueue(2);
+                }
+            }
+        }
+
+        let mut visitor = FanOutVisitor(Vec::new());
+        WorklistEngine::new(&graph)
+            .initialize([0])
+            .run(&mut visitor);
+
+        assert_eq!(visitor.0, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_worklist_visited_reflects_processed_nodes() {
+        let graph = TestGraph {
+            successors: vec![vec![1, 2], vec![], vec![]],
+        };
+
+        let mut engine = WorklistEngine::new(&graph);
+        engine.initialize([0]).run(&mut |_| {});
+
+        assert!(engine.visited().contains(&0));
+        assert!(engine.visited().contains(&1));
+        assert!(engine.visited().contains(&2));
+        assert!(!engine.visited().contains(&3));
+    }
+
+    #[test]
+    fn test_fixed_point_analyze_applies_transfer_and_join() {
+        struct ReachabilityAnalysis;
+
+        impl Analysis<usize> for ReachabilityAnalysis {
+            type State = Vec<usize>;
+
+            fn transfer(&mut self, node: usize, state: &Self::State) -> Self::State {
+                let mut state = state.clone();
+                if !state.contains(&node) {
+                    state.push(node);
+                    state.sort_unstable();
+                }
+                state
+            }
+
+            fn join(&self, a: &Self::State, b: &Self::State) -> Self::State {
+                let mut state = a.clone();
+                for node in b {
+                    if !state.contains(node) {
+                        state.push(*node);
+                    }
+                }
+                state.sort_unstable();
+                state
+            }
+        }
+
+        let graph = TestGraph {
+            successors: vec![vec![1, 2], vec![3], vec![3], vec![]],
+        };
+        let mut analysis = ReachabilityAnalysis;
+
+        let states = fixed_point_analyze(&graph, [0], Vec::new(), &mut analysis);
+
+        assert_eq!(states.get(&0).unwrap(), &vec![]);
+        assert_eq!(states.get(&1).unwrap(), &vec![0]);
+        assert_eq!(states.get(&2).unwrap(), &vec![0]);
+        assert_eq!(states.get(&3).unwrap(), &vec![0, 1, 2]);
+    }
+}

--- a/crates/sbpf_ir/src/lib.rs
+++ b/crates/sbpf_ir/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod cfg;
+pub mod dataflow;
+pub mod graph_engine;
+
+pub use {
+    cfg::{Block, BlockId, Cfg, CfgFunction, FunctionId, InputNode, control_flow_graph},
+    dataflow::{
+        InstId, InstructionNode, InstructionVisitor, walk_instruction_node, walk_instruction_nodes,
+    },
+};

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -197,7 +197,11 @@ pub fn build(args: BuildArgs) -> Result<()> {
             None
         };
 
-        let options = AssemblerOption { arch, debug_mode };
+        let options = AssemblerOption {
+            arch,
+            debug_mode,
+            ..AssemblerOption::default()
+        };
         let assembler = Assembler::new(options);
         let resolver = FsFileResolver::new();
 


### PR DESCRIPTION
This PR adds a new CFG foundation and a transform layer for SBPF assembly analysis and optimization.

It introduces two workspace crates:
  - `crates/sbpf_ir`: control-flow graph, basic blocks, function grouping, instruction nodes, DFS traversal and worklist traversal.
  - `crates/analyzer` published as `sbpf-transform`: currently provides CFG DOT dumping and dead-function removal (these 2 also serves as examples of how to use CFG and graph engine to write analysis)

Assembler integration was added behind `OptimizationConfig`:
  - `OptimizationConfig::{disabled, enabled, with_cfg_dump_dir}` controls whether CFG-based optimization runs.
  - The optimizer canonicalizes numeric and relative jump/call targets into labels before analysis.
  - DFE pass removes function-entry regions that are unreachable from the declared entry via `call` imm.
  - Optional CFG dumps are written as dfe-before.dot and dfe-after.dot (since it's the only optimization pass at the moment)

The assembler AST/build pipeline was refactored so parsing now returns ProgramLayout, then optimization (enabled for linker workflow), label resolution, relocation handling, and code/data section construction happen through the new layout flow.