### PR TITLE
feat: add CfgDumpOverlay trait and dump_cfg_with

### DIFF
--- a/crates/analyzer/src/dump_cfg.rs
+++ b/crates/analyzer/src/dump_cfg.rs
@@ -1,10 +1,33 @@
 use {
     sbpf_common::instruction::AsmFormat,
-    sbpf_ir::{Cfg, graph_engine::DfsEngine},
+    sbpf_ir::{BlockId, Cfg, graph_engine::DfsEngine},
     std::fmt::Write,
 };
 
+/// into a DOT graph without modifying [`dump_cfg`] itself.
+pub trait CfgDumpOverlay {
+    fn block_extra_label(&self, _block_id: BlockId) -> String {
+        String::new()
+    }
+
+    fn block_attrs(&self, _block_id: BlockId) -> Vec<(&'static str, String)> {
+        vec![]
+    }
+
+    fn function_extra_label(&self, _function_id: usize) -> String {
+        String::new()
+    }
+}
+
+struct NoOverlay;
+impl CfgDumpOverlay for NoOverlay {}
+
 pub fn dump_cfg(cfg: &Cfg) -> String {
+    dump_cfg_with(cfg, &NoOverlay)
+}
+
+/// Like [`dump_cfg`] but accepts an [`CfgDumpOverlay`] to inject custom labels and
+pub fn dump_cfg_with<O: CfgDumpOverlay>(cfg: &Cfg, overlay: &O) -> String {
     let mut output = String::from("digraph cfg {\n  node [shape=box];\n");
 
     // Emit one DOT subgraph cluster per function, with each block declared inside
@@ -12,19 +35,43 @@ pub fn dump_cfg(cfg: &Cfg) -> String {
     for (function_id, function) in cfg.functions().iter().enumerate() {
         writeln!(output, "  subgraph cluster_function_{function_id} {{")
             .expect("writing to a String cannot fail");
-        writeln!(
-            output,
-            "    label=\"{}\";",
-            escape_dot_label(function.name())
-        )
-        .expect("writing to a String cannot fail");
+
+        let func_extra = overlay.function_extra_label(function_id);
+        if func_extra.is_empty() {
+            writeln!(
+                output,
+                "    label=\"{}\";",
+                escape_dot_label(function.name())
+            )
+            .expect("writing to a String cannot fail");
+        } else {
+            writeln!(
+                output,
+                "    label=\"{}\\n{}\";",
+                escape_dot_label(function.name()),
+                escape_dot_label(&func_extra)
+            )
+            .expect("writing to a String cannot fail");
+        }
 
         for (&block_id, block) in function.block_ids().iter().zip(function.blocks().iter()) {
             let inst_base = cfg.block_inst_offset(block_id);
+            let mut label = block_label(block_id, inst_base, block);
+            let block_extra = overlay.block_extra_label(block_id);
+            if !block_extra.is_empty() {
+                write!(label, "{}\\l", escape_dot_label(&block_extra))
+                    .expect("writing to a String cannot fail");
+            }
+
+            let attrs = overlay.block_attrs(block_id);
+            let attrs_str: String = attrs
+                .iter()
+                .map(|(k, v)| format!(", {k}=\"{v}\""))
+                .collect();
+
             writeln!(
                 output,
-                "    block_{block_id} [label=\"{}\"];",
-                block_label(block_id, inst_base, block)
+                "    block_{block_id} [label=\"{label}\"{attrs_str}];",
             )
             .expect("writing to a String cannot fail");
         }
@@ -114,6 +161,57 @@ mod tests {
         assert!(dot.contains("label=\"target\";"));
         assert!(dot.contains("0: ja target\\l"));
         assert!(dot.contains("block_0 -> block_2;"));
+    }
+
+    #[test]
+    fn test_dump_cfg_with_overlay_applies_extra_label_and_attrs() {
+        let exit = instruction(Opcode::Exit, None);
+        let nodes = [InputNode::Label("entry"), InputNode::Instruction(&exit)];
+        let cfg = control_flow_graph(nodes, &HashSet::from(["entry".to_string()]), None);
+
+        struct HighlightAll;
+        impl CfgDumpOverlay for HighlightAll {
+            fn block_extra_label(&self, _block_id: BlockId) -> String {
+                "CU: 99".to_string()
+            }
+            fn block_attrs(&self, _block_id: BlockId) -> Vec<(&'static str, String)> {
+                vec![
+                    ("style", "filled".to_string()),
+                    ("fillcolor", "#e74c3c".to_string()),
+                ]
+            }
+            fn function_extra_label(&self, _function_id: usize) -> String {
+                "total CU: 99".to_string()
+            }
+        }
+
+        let dot = dump_cfg_with(&cfg, &HighlightAll);
+
+        assert!(dot.contains("CU: 99\\l"), "block extra label present");
+        assert!(dot.contains(r#"style="filled""#), "style attr present");
+        assert!(
+            dot.contains(r##"fillcolor="#e74c3c""##),
+            "fillcolor attr present"
+        );
+        assert!(dot.contains("total CU: 99"), "function extra label present");
+    }
+
+    #[test]
+    fn test_dump_cfg_with_no_overlay_matches_dump_cfg() {
+        let jump = instruction(Opcode::Ja, Some(Either::Left("target".to_string())));
+        let dead_exit = instruction(Opcode::Exit, None);
+        let target_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entry"),
+            InputNode::Instruction(&jump),
+            InputNode::Instruction(&dead_exit),
+            InputNode::Label("target"),
+            InputNode::Instruction(&target_exit),
+        ];
+        let function_entries = HashSet::from(["entry".to_string(), "target".to_string()]);
+        let cfg = control_flow_graph(nodes, &function_entries, None);
+
+        assert_eq!(dump_cfg(&cfg), dump_cfg_with(&cfg, &NoOverlay));
     }
 
     fn instruction(opcode: Opcode, off: Option<Either<String, i16>>) -> Instruction {

--- a/crates/analyzer/src/lib.rs
+++ b/crates/analyzer/src/lib.rs
@@ -2,6 +2,6 @@ pub mod dump_cfg;
 pub mod remove_dead_functions;
 
 pub use {
-    dump_cfg::dump_cfg,
+    dump_cfg::{CfgDumpOverlay, dump_cfg, dump_cfg_with},
     remove_dead_functions::{RemovedFunction, remove_dead_functions},
 };


### PR DESCRIPTION
Plugin trait that lets downstream passes annotate the CFG DOT output without modifying dump_cfg