### PR TITLE
fix: replace panicking `Number` arithmetic with checked operators to prevent ICEs on constant-expression overflow

### DIFF
--- a/crates/assembler/src/errors.rs
+++ b/crates/assembler/src/errors.rs
@@ -75,6 +75,11 @@ define_compile_errors! {
         label = "Out of range literal",
         fields = { span: Range<usize> }
     },
+    ArithmeticError {
+        error = "{error}",
+        label = "Invalid constant expression",
+        fields = { error: String, span: Range<usize> }
+    },
     InvalidRODataDirective {
         error = "Invalid rodata directive",
         label = "Invalid rodata directive",

--- a/crates/assembler/src/lib.rs
+++ b/crates/assembler/src/lib.rs
@@ -409,6 +409,78 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_const_expr_overflow_errors() {
+        for expr in ["BIG + 1", "BIG * 2"] {
+            let source = format!(
+                r#"
+                .globl entrypoint
+                .equ BIG, 0x7FFFFFFFFFFFFFFF
+                entrypoint:
+                    lddw r1, {expr}
+                    exit
+                "#
+            );
+            let result = assemble(&source);
+            assert!(result.is_err(), "expected error for '{expr}'");
+            assert!(matches!(
+                result.unwrap_err().first(),
+                Some(CompileError::ArithmeticError { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn test_assemble_const_expr_div_by_zero_errors() {
+        let source = r#"
+        .globl entrypoint
+        entrypoint:
+            lddw r1, 8 / 0
+            exit
+        "#;
+        let result = assemble(source);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.first(),
+            Some(CompileError::ArithmeticError { .. })
+        ));
+        // The diagnostic must point at the offending expression, not 0..len.
+        assert!(errors[0].span().start > 0);
+    }
+
+    #[test]
+    fn test_assemble_const_expr_overflow_in_directive_errors() {
+        // The directive-value evaluator must also be overflow-safe.
+        let source = r#"
+        .globl entrypoint
+        .equ BAD, 0x7FFFFFFFFFFFFFFF + 1
+        entrypoint:
+            lddw r1, BAD
+            exit
+        "#;
+        let result = assemble(source);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err().first(),
+            Some(CompileError::ArithmeticError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_assemble_valid_const_expr_still_folds() {
+        // Regression: in-range arithmetic must keep folding correctly.
+        let source = r#"
+        .globl entrypoint
+        .equ A, 0x10
+        .equ B, 0x20
+        entrypoint:
+            lddw r1, A * 4 + B
+            exit
+        "#;
+        assert!(assemble(source).is_ok());
+    }
+
+    #[test]
     fn test_assemble_duplicate_label_error() {
         let source = r#"
         .globl entrypoint

--- a/crates/assembler/src/parser/common.rs
+++ b/crates/assembler/src/parser/common.rs
@@ -137,14 +137,26 @@ fn eval_operand_expression(
     let mut result = terms[0].clone();
     for (i, op) in ops.iter().enumerate() {
         if i + 1 < terms.len() {
-            let rhs = terms[i + 1].clone();
-            result = match *op {
-                "+" => result + rhs,
-                "-" => result - rhs,
-                "*" => result * rhs,
-                "/" => result / rhs,
-                _ => result,
+            let rhs = &terms[i + 1];
+            let folded = match *op {
+                "+" => result.checked_add(rhs),
+                "-" => result.checked_sub(rhs),
+                "*" => result.checked_mul(rhs),
+                "/" => result.checked_div(rhs),
+                _ => Some(result.clone()),
             };
+            result = folded.ok_or_else(|| {
+                let detail = if *op == "/" && rhs.to_i64() == 0 {
+                    "division by zero in constant expression".to_string()
+                } else {
+                    format!("arithmetic overflow in constant expression ('{op}')")
+                };
+                CompileError::ArithmeticError {
+                    error: detail,
+                    span: span_range.clone(),
+                    custom_label: None,
+                }
+            })?;
         }
     }
 

--- a/crates/assembler/src/parser/directive.rs
+++ b/crates/assembler/src/parser/directive.rs
@@ -241,13 +241,25 @@ fn eval_expression(
         if stack.len() >= 2 {
             let b = stack.pop().unwrap();
             let a = stack.pop().unwrap();
-            let result = match op {
-                "+" => a + b,
-                "-" => a - b,
-                "*" => a * b,
-                "/" => a / b,
-                _ => a,
+            let folded = match op {
+                "+" => a.checked_add(&b),
+                "-" => a.checked_sub(&b),
+                "*" => a.checked_mul(&b),
+                "/" => a.checked_div(&b),
+                _ => Some(a),
             };
+            let result = folded.ok_or_else(|| {
+                let detail = if op == "/" && b.to_i64() == 0 {
+                    "division by zero in constant expression".to_string()
+                } else {
+                    format!("arithmetic overflow in constant expression ('{op}')")
+                };
+                CompileError::ArithmeticError {
+                    error: detail,
+                    span: span_range.clone(),
+                    custom_label: None,
+                }
+            })?;
             stack.push(result);
         }
     }

--- a/crates/common/src/inst_param.rs
+++ b/crates/common/src/inst_param.rs
@@ -34,6 +34,29 @@ impl Number {
             Number::Addr(a) => *a,
         }
     }
+
+    fn retag(&self, other: &Number, value: i64) -> Number {
+        match (self, other) {
+            (Number::Int(_), Number::Int(_)) => Number::Int(value),
+            _ => Number::Addr(value),
+        }
+    }
+
+    pub fn checked_add(&self, other: &Number) -> Option<Number> {
+        Some(self.retag(other, self.to_i64().checked_add(other.to_i64())?))
+    }
+
+    pub fn checked_sub(&self, other: &Number) -> Option<Number> {
+        Some(self.retag(other, self.to_i64().checked_sub(other.to_i64())?))
+    }
+
+    pub fn checked_mul(&self, other: &Number) -> Option<Number> {
+        Some(self.retag(other, self.to_i64().checked_mul(other.to_i64())?))
+    }
+
+    pub fn checked_div(&self, other: &Number) -> Option<Number> {
+        Some(self.retag(other, self.to_i64().checked_div(other.to_i64())?))
+    }
 }
 
 impl fmt::Display for Number {
@@ -41,54 +64,6 @@ impl fmt::Display for Number {
         match self {
             Number::Int(i) => write!(f, "{}", i),
             Number::Addr(a) => write!(f, "{}", a),
-        }
-    }
-}
-
-impl std::ops::Add for Number {
-    type Output = Number;
-    fn add(self, other: Self) -> Number {
-        match (self, other) {
-            (Number::Int(a), Number::Int(b)) => Number::Int(a + b),
-            (Number::Addr(a), Number::Addr(b)) => Number::Addr(a + b),
-            (Number::Int(a), Number::Addr(b)) => Number::Addr(a + b),
-            (Number::Addr(a), Number::Int(b)) => Number::Addr(a + b),
-        }
-    }
-}
-
-impl std::ops::Sub for Number {
-    type Output = Number;
-    fn sub(self, other: Self) -> Number {
-        match (self, other) {
-            (Number::Int(a), Number::Int(b)) => Number::Int(a - b),
-            (Number::Addr(a), Number::Addr(b)) => Number::Addr(a - b),
-            (Number::Int(a), Number::Addr(b)) => Number::Addr(a - b),
-            (Number::Addr(a), Number::Int(b)) => Number::Addr(a - b),
-        }
-    }
-}
-
-impl std::ops::Mul for Number {
-    type Output = Number;
-    fn mul(self, other: Self) -> Number {
-        match (self, other) {
-            (Number::Int(a), Number::Int(b)) => Number::Int(a * b),
-            (Number::Addr(a), Number::Addr(b)) => Number::Addr(a * b),
-            (Number::Int(a), Number::Addr(b)) => Number::Addr(a * b),
-            (Number::Addr(a), Number::Int(b)) => Number::Addr(a * b),
-        }
-    }
-}
-
-impl std::ops::Div for Number {
-    type Output = Number;
-    fn div(self, other: Self) -> Number {
-        match (self, other) {
-            (Number::Int(a), Number::Int(b)) => Number::Int(a / b),
-            (Number::Addr(a), Number::Addr(b)) => Number::Addr(a / b),
-            (Number::Int(a), Number::Addr(b)) => Number::Addr(a / b),
-            (Number::Addr(a), Number::Int(b)) => Number::Addr(a / b),
         }
     }
 }
@@ -131,78 +106,77 @@ mod tests {
     }
 
     #[test]
-    fn test_number_add() {
+    fn test_number_checked_add() {
         // Int + Int
-        let result = Number::Int(10) + Number::Int(20);
-        assert_eq!(result, Number::Int(30));
-
+        assert_eq!(
+            Number::Int(10).checked_add(&Number::Int(20)),
+            Some(Number::Int(30))
+        );
         // Addr + Addr
-        let result = Number::Addr(10) + Number::Addr(20);
-        assert_eq!(result, Number::Addr(30));
-
-        // Int + Addr
-        let result = Number::Int(10) + Number::Addr(20);
-        assert_eq!(result, Number::Addr(30));
-
-        // Addr + Int
-        let result = Number::Addr(10) + Number::Int(20);
-        assert_eq!(result, Number::Addr(30));
+        assert_eq!(
+            Number::Addr(10).checked_add(&Number::Addr(20)),
+            Some(Number::Addr(30))
+        );
+        // Int + Addr / Addr + Int both tag the result as Addr
+        assert_eq!(
+            Number::Int(10).checked_add(&Number::Addr(20)),
+            Some(Number::Addr(30))
+        );
+        assert_eq!(
+            Number::Addr(10).checked_add(&Number::Int(20)),
+            Some(Number::Addr(30))
+        );
     }
 
     #[test]
-    fn test_number_sub() {
-        // Int - Int
-        let result = Number::Int(30) - Number::Int(10);
-        assert_eq!(result, Number::Int(20));
-
-        // Addr - Addr
-        let result = Number::Addr(30) - Number::Addr(10);
-        assert_eq!(result, Number::Addr(20));
-
-        // Int - Addr
-        let result = Number::Int(30) - Number::Addr(10);
-        assert_eq!(result, Number::Addr(20));
-
-        // Addr - Int
-        let result = Number::Addr(30) - Number::Int(10);
-        assert_eq!(result, Number::Addr(20));
+    fn test_number_checked_sub() {
+        assert_eq!(
+            Number::Int(30).checked_sub(&Number::Int(10)),
+            Some(Number::Int(20))
+        );
+        assert_eq!(
+            Number::Addr(30).checked_sub(&Number::Int(10)),
+            Some(Number::Addr(20))
+        );
     }
 
     #[test]
-    fn test_number_mul() {
-        // Int * Int
-        let result = Number::Int(5) * Number::Int(4);
-        assert_eq!(result, Number::Int(20));
-
-        // Addr * Addr
-        let result = Number::Addr(5) * Number::Addr(4);
-        assert_eq!(result, Number::Addr(20));
-
-        // Int * Addr
-        let result = Number::Int(5) * Number::Addr(4);
-        assert_eq!(result, Number::Addr(20));
-
-        // Addr * Int
-        let result = Number::Addr(5) * Number::Int(4);
-        assert_eq!(result, Number::Addr(20));
+    fn test_number_checked_mul() {
+        assert_eq!(
+            Number::Int(5).checked_mul(&Number::Int(4)),
+            Some(Number::Int(20))
+        );
+        assert_eq!(
+            Number::Addr(5).checked_mul(&Number::Int(4)),
+            Some(Number::Addr(20))
+        );
     }
 
     #[test]
-    fn test_number_div() {
-        // Int / Int
-        let result = Number::Int(20) / Number::Int(4);
-        assert_eq!(result, Number::Int(5));
+    fn test_number_checked_div() {
+        assert_eq!(
+            Number::Int(20).checked_div(&Number::Int(4)),
+            Some(Number::Int(5))
+        );
+        assert_eq!(
+            Number::Addr(20).checked_div(&Number::Int(4)),
+            Some(Number::Addr(5))
+        );
+    }
 
-        // Addr / Addr
-        let result = Number::Addr(20) / Number::Addr(4);
-        assert_eq!(result, Number::Addr(5));
+    #[test]
+    fn test_number_checked_arithmetic_reports_overflow() {
+        // Overflow returns None instead of panicking / wrapping.
+        assert_eq!(Number::Int(i64::MAX).checked_add(&Number::Int(1)), None);
+        assert_eq!(Number::Int(i64::MIN).checked_sub(&Number::Int(1)), None);
+        assert_eq!(Number::Int(i64::MAX).checked_mul(&Number::Int(2)), None);
+        // i64::MIN / -1 overflows two's-complement division.
+        assert_eq!(Number::Int(i64::MIN).checked_div(&Number::Int(-1)), None);
+    }
 
-        // Int / Addr
-        let result = Number::Int(20) / Number::Addr(4);
-        assert_eq!(result, Number::Addr(5));
-
-        // Addr / Int
-        let result = Number::Addr(20) / Number::Int(4);
-        assert_eq!(result, Number::Addr(5));
+    #[test]
+    fn test_number_checked_div_by_zero() {
+        assert_eq!(Number::Int(8).checked_div(&Number::Int(0)), None);
+        assert_eq!(Number::Addr(8).checked_div(&Number::Int(0)), None);
     }
 }


### PR DESCRIPTION
### Problem

`Number`'s `Add`/`Sub`/`Mul`/`Div` operator impls (`crates/common/src/inst_param.rs`) performed raw `i64` arithmetic with no overflow or division-by-zero protection. These operators are used by both constant-expression evaluators in the assembler:

- `eval_operand_expression` (`parser/common.rs`) — instruction operands, e.g. `lddw r1, BIG + 1`
- `eval_expression` (`parser/directive.rs`) — `.equ NAME, <expr>` directive values

As a result, any user-written constant expression that overflowed `i64` (debug builds) or divided by zero (all builds) crashed the assembler with an internal panic instead of producing a diagnostic:

```asm
.equ BIG, 0x7FFFFFFFFFFFFFFF
entrypoint:
    lddw r1, BIG + 1   ; panics: attempt to add with overflow

    lddw r1, 8 / 0     ; panics: attempt to divide by zero
```

In release builds, overflow instead wraps silently, producing a corrupted immediate with no warning at all.

### Fix

- Removed the panicking operator trait impls on `Number` and replaced them with `checked_add` / `checked_sub` / `checked_mul` / `checked_div`, each returning `Option<Number>`.
- Added a private `retag` helper that preserves the existing `Int`/`Addr` variant-selection rule (result is `Addr` if either operand is `Addr`, otherwise `Int`), so valid expressions fold to identical values as before.
- Added a new `CompileError::ArithmeticError` variant and wired both evaluators (`eval_operand_expression` and `eval_expression`) to surface it with a clear message (overflow vs. division by zero) and the original source span, instead of panicking.

### Scope note

This only touches the constant-expression evaluators (assemble-time arithmetic on `Number`). It does **not** touch the unrelated offset/immediate truncation behavior in `parser/common.rs` (`to_i16()`, `wrapping_add` in `parse_memory_ref`/`parse_jump_target`) or final bytecode encoding — that's tracked separately in #97 and intentionally out of scope here, since the maintainer has a different (warning-based) direction in mind for that one.

### Behavior change

Constant expressions that previously **wrapped silently** in release builds (e.g. `i64::MAX + 1`) now produce a compile error instead. This is intentional: there's no valid program that depends on silently wrapped constant arithmetic, and failing loudly at assemble time is strictly safer than emitting a corrupted immediate. Division by zero already panicked unconditionally in both build profiles, so that case is a pure improvement.

### Testing

- New unit tests in `crates/common/src/inst_param.rs` covering checked-arithmetic overflow and division-by-zero for all four operators.
- New integration tests in `crates/assembler/src/lib.rs`:
  - `test_assemble_const_expr_overflow_errors`
  - `test_assemble_const_expr_div_by_zero_errors`
  - `test_assemble_const_expr_overflow_in_directive_errors`
  - `test_assemble_valid_const_expr_still_folds` (regression check that legitimate folding, e.g. `A * 4 + B`, is unaffected)
- `cargo build`, `cargo fmt --check`, `cargo clippy -p sbpf-common -p sbpf-assembler`, and `cargo test --workspace` (599 passed) all clean.


Fixes: #132 