### PR TITLE
fix(init): prevent path traversal in project name

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -52,7 +52,7 @@ pub fn init(args: InitArgs) -> Result<(), Error> {
         .any(|c| c == std::path::Component::ParentDir)
     {
         anyhow::bail!(
-            "Invalid project name '{}': must not contain '..' components",
+            "Invalid project path '{}': paths must not traverse parent directories (..)",
             project_name
         );
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -47,13 +47,12 @@ pub fn init(args: InitArgs) -> Result<(), Error> {
         },
     };
 
-    if project_name == "."
-        || project_name == ".."
-        || project_name.contains('/')
-        || project_name.contains('\\')
+    if std::path::Path::new(&project_name)
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
     {
         anyhow::bail!(
-            "Invalid project name '{}': must be a plain directory name with no path separators",
+            "Invalid project name '{}': must not contain '..' components",
             project_name
         );
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -47,12 +47,16 @@ pub fn init(args: InitArgs) -> Result<(), Error> {
         },
     };
 
-    let project_name = std::path::Path::new(&project_name)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
-        .ok_or_else(|| anyhow::anyhow!("Invalid project name"))?
-        .to_string();
+    if project_name == "."
+        || project_name == ".."
+        || project_name.contains('/')
+        || project_name.contains('\\')
+    {
+        anyhow::bail!(
+            "Invalid project name '{}': must be a plain directory name with no path separators",
+            project_name
+        );
+    }
 
     let current_dir = std::env::current_dir()?;
     let project_path = current_dir.join(&project_name);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -47,6 +47,13 @@ pub fn init(args: InitArgs) -> Result<(), Error> {
         },
     };
 
+    let project_name = std::path::Path::new(&project_name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
+        .ok_or_else(|| anyhow::anyhow!("Invalid project name"))?
+        .to_string();
+
     let current_dir = std::env::current_dir()?;
     let project_path = current_dir.join(&project_name);
 


### PR DESCRIPTION
`sbpf init ../foo` created the project outside cwd because the name was passed to `Path::join()` without sanitization. With `--ts-tests` this also ran `yarn install` in the traversed directory, which would execute any `postinstall` scripts sitting there.

Fix rejects project names that contain '..' path components, so path traversal is an error rather than silently redirected. Plain names (foo) and subdir paths (example/foo) still work fine.

  - [x] `sbpf init ../foo`  -> errors: "must not contain `'..'` components"
  - [x] `sbpf init foo `    -> creates foo in cwd (unchanged)
  - [x]  `sbpf init example/foo` -> creates foo under `example/` in cwd
  
  ISSUE ->
  
<img width="1224" height="180" alt="image" src="https://github.com/user-attachments/assets/ea1a89f8-6b5f-498a-98cd-e57338fed6ec" />

  FIX ->
  
<img width="955" height="122" alt="image" src="https://github.com/user-attachments/assets/6e0ad0b7-07d8-482e-bbed-28e6f2da3b9a" />
