### PR TITLE
ci: test downstream sbpf-linker against workspace crates

### DIFF
--- a/.github/workflows/downstream-sbpf-linker.yml
+++ b/.github/workflows/downstream-sbpf-linker.yml
@@ -1,0 +1,105 @@
+name: downstream
+
+# Builds and tests sbpf-linker at its default-branch HEAD against the sbpf
+# crates in this checkout, so API breakage in the crates the linker consumes
+# (sbpf-assembler, sbpf-common and their workspace dependencies) is caught
+# here before a release is published.
+#
+# The version rewrite in the patch step is load-bearing: the linker pins the
+# published crate versions, and a bare [patch.crates-io] whose local version
+# does not satisfy that requirement is silently discarded by cargo — the build
+# would fall back to crates.io and test the wrong code. See the verify step,
+# which fails the job if that ever happens.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "crates/assembler/**"
+      - "crates/common/**"
+      - "crates/analyzer/**"
+      - "crates/sbpf_ir/**"
+      - "crates/sbpf-syscall-map/**"
+      - "Cargo.toml"
+      - ".github/workflows/downstream-sbpf-linker.yml"
+  pull_request:
+    paths:
+      - "crates/assembler/**"
+      - "crates/common/**"
+      - "crates/analyzer/**"
+      - "crates/sbpf_ir/**"
+      - "crates/sbpf-syscall-map/**"
+      - "Cargo.toml"
+      - ".github/workflows/downstream-sbpf-linker.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbpf-linker:
+    name: sbpf-linker (HEAD) against local sbpf crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Checkout sbpf-linker (default branch HEAD)
+        uses: actions/checkout@v5
+        with:
+          repository: blueshift-gg/sbpf-linker
+          path: sbpf-linker
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rust-src
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: sbpf-linker
+          cache-on-failure: true
+
+      - name: Install FileCheck
+        run: sudo apt-get update && sudo apt-get install -y llvm-18-tools
+
+      - name: Patch sbpf crates to this checkout
+        working-directory: sbpf-linker
+        run: |
+          sbpf_ver="$(cargo metadata --manifest-path ../Cargo.toml --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "sbpf-common") | .version')"
+          echo "patching sbpf-assembler and sbpf-common to =${sbpf_ver} (local path)"
+          for crate in sbpf-assembler sbpf-common; do
+            sed -E -i'' \
+              -e "s|^(${crate} = \")[=<>^~]*[0-9.]+([^\"]*\".*)|\1=${sbpf_ver}\2|" \
+              -e "s|^(${crate} = \{ version = \")[=<>^~]*[0-9.]+([^\"]*\".*)|\1=${sbpf_ver}\2|" \
+              Cargo.toml
+          done
+          {
+            echo ""
+            echo "[patch.crates-io]"
+            echo "sbpf-assembler = { path = \"../crates/assembler\" }"
+            echo "sbpf-common = { path = \"../crates/common\" }"
+          } >> Cargo.toml
+
+      - name: Verify the patch took effect
+        working-directory: sbpf-linker
+        run: |
+          tree="$(cargo tree --prefix none --edges normal | grep -E '^sbpf-(assembler|common) ' | sort -u)"
+          echo "${tree}"
+          if [ -z "${tree}" ]; then
+            echo "::error::sbpf-assembler/sbpf-common not found in the linker dependency tree"
+            exit 1
+          fi
+          if echo "${tree}" | grep -v "(/"; then
+            echo "::error::sbpf crates still resolve to crates.io — the [patch] was discarded"
+            exit 1
+          fi
+
+      - name: Run sbpf-linker test suite
+        working-directory: sbpf-linker
+        run: cargo test -- --nocapture

--- a/.github/workflows/downstream-sbpf-linker.yml
+++ b/.github/workflows/downstream-sbpf-linker.yml
@@ -1,9 +1,7 @@
 name: downstream
 
-# Builds and tests sbpf-linker at downstream-consumer HEAD against the sbpf
-# crates in this checkout, so API breakage in the crates the linker consumes
-# (sbpf-assembler, sbpf-common and their workspace dependencies) is caught
-# here before a release is published.
+# Build and test sbpf-linker at sbpf-linker-next HEAD against the sbpf
+# crates in this checkout, so API breakage is caught here before a release is published.
 #
 # The git-source patch below replaces the linker's sbpf dependencies with this
 # checkout. The version rewrite keeps local versions compatible with explicit
@@ -13,24 +11,7 @@ name: downstream
 on:
   push:
     branches: [master]
-    paths:
-      - "crates/assembler/**"
-      - "crates/common/**"
-      - "crates/analyzer/**"
-      - "crates/sbpf_ir/**"
-      - "crates/sbpf-syscall-map/**"
-      - "Cargo.toml"
-      - ".github/workflows/downstream-sbpf-linker.yml"
   pull_request:
-    paths:
-      - "crates/assembler/**"
-      - "crates/common/**"
-      - "crates/analyzer/**"
-      - "crates/sbpf_ir/**"
-      - "crates/sbpf-syscall-map/**"
-      - "Cargo.toml"
-      - ".github/workflows/downstream-sbpf-linker.yml"
-  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -50,8 +31,8 @@ jobs:
       - name: Checkout sbpf-linker 
         uses: actions/checkout@v5
         with:
-          repository: BretasArthur1/sbpf-linker
-          ref: downstream-consumer
+          repository: blueshift-gg/sbpf-linker
+          ref: sbpf-linker-next
           path: sbpf-linker
 
       - uses: dtolnay/rust-toolchain@master
@@ -120,10 +101,11 @@ jobs:
 
           This job tests sbpf-linker against the sbpf crates from this checkout.
 
-          Review the test logs to identify the cause. If your changes introduce an API incompatibility, you must submit a PR to adapt sbpf-linker to these changes.
-          Opening a companion PR does not automatically make this check pass: this
-          workflow tests BretasArthur1/sbpf-linker's downstream-consumer branch, not
-          your companion PR branch. Coordinate with a maintainer to validate both changes.
+          Review the test logs to identify the cause. If your changes introduce an API incompatibility, 
+          you must submit a PR to adapt sbpf-linker to these changes.
+          Opening a companion PR does not automatically make this check pass, 
+          this workflow tests against sbpf-linker-next branch, not your companion PR branch. 
+          Coordinate with a maintainer to validate both changes.
 
           See [Compatibility with sbpf-linker](https://github.com/blueshift-gg/sbpf/blob/master/CONTRIBUTING.md#compatibility-with-sbpf-linker) for the contribution process.
           EOF

--- a/.github/workflows/downstream-sbpf-linker.yml
+++ b/.github/workflows/downstream-sbpf-linker.yml
@@ -1,15 +1,14 @@
 name: downstream
 
-# Builds and tests sbpf-linker at its default-branch HEAD against the sbpf
+# Builds and tests sbpf-linker at downstream-consumer HEAD against the sbpf
 # crates in this checkout, so API breakage in the crates the linker consumes
 # (sbpf-assembler, sbpf-common and their workspace dependencies) is caught
 # here before a release is published.
 #
-# The version rewrite in the patch step is load-bearing: the linker pins the
-# published crate versions, and a bare [patch.crates-io] whose local version
-# does not satisfy that requirement is silently discarded by cargo — the build
-# would fall back to crates.io and test the wrong code. See the verify step,
-# which fails the job if that ever happens.
+# The git-source patch below replaces the linker's sbpf dependencies with this
+# checkout. The version rewrite keeps local versions compatible with explicit
+# version requirements. Verification checks both crates resolved manifest paths
+# so an unused patch cannot silently result in testing the wrong code.
 
 on:
   push:
@@ -90,17 +89,41 @@ jobs:
       - name: Verify the patch took effect
         working-directory: sbpf-linker
         run: |
-          tree="$(cargo tree --prefix none --edges normal | grep -E '^sbpf-(assembler|common) ' | sort -u)"
-          echo "${tree}"
-          if [ -z "${tree}" ]; then
-            echo "::error::sbpf-assembler/sbpf-common not found in the linker dependency tree"
-            exit 1
-          fi
-          if echo "${tree}" | grep -v "(/"; then
-          echo "::error::sbpf crates do not resolve to local paths — the [patch] was not applied"
-            exit 1
-          fi
+          cargo metadata --format-version 1 > "$RUNNER_TEMP/linker-metadata.json"
+          checkout_root="$(realpath ..)"
+          for crate in assembler common; do
+            expected_manifest="$checkout_root/crates/$crate/Cargo.toml"
+            if ! jq -e --arg name "sbpf-$crate" --arg manifest "$expected_manifest" '
+              [.resolve.nodes[].id] as $resolved
+              | [.packages[]
+                 | select(.id as $id | $resolved | index($id))
+                 | select(.name == $name)]
+              | length > 0 and all(.[]; .source == null and .manifest_path == $manifest)
+            ' "$RUNNER_TEMP/linker-metadata.json"; then
+              echo "::error::sbpf-$crate must resolve only to $expected_manifest — check the dependency source and [patch] configuration"
+              exit 1
+            fi
+          done
 
       - name: Run sbpf-linker test suite
+        id: linker-tests
         working-directory: sbpf-linker
         run: cargo test -- --nocapture
+
+      - name: Explain downstream compatibility requirements
+        if: ${{ failure() && steps.linker-tests.outcome == 'failure' }}
+        run: |
+          echo "::error title=Downstream sbpf-linker tests failed::If this failure is caused by an sbpf API change, a companion sbpf-linker PR is required. See the job summary and CONTRIBUTING.md for instructions."
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Downstream compatibility check failed
+
+          This job tests sbpf-linker against the sbpf crates from this checkout.
+
+          Review the test logs to identify the cause. If your changes introduce an API incompatibility, you must submit a PR to adapt sbpf-linker to these changes.
+          Opening a companion PR does not automatically make this check pass: this
+          workflow tests BretasArthur1/sbpf-linker's downstream-consumer branch, not
+          your companion PR branch. Coordinate with a maintainer to validate both changes.
+
+          See [Compatibility with sbpf-linker](https://github.com/blueshift-gg/sbpf/blob/master/CONTRIBUTING.md#compatibility-with-sbpf-linker) for the contribution process.
+          EOF

--- a/.github/workflows/downstream-sbpf-linker.yml
+++ b/.github/workflows/downstream-sbpf-linker.yml
@@ -42,16 +42,17 @@ concurrency:
 
 jobs:
   sbpf-linker:
-    name: sbpf-linker (HEAD) against local sbpf crates
+    name: sbpf-linker against local sbpf crates
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
-      - name: Checkout sbpf-linker (default branch HEAD)
+      - name: Checkout sbpf-linker 
         uses: actions/checkout@v5
         with:
-          repository: blueshift-gg/sbpf-linker
+          repository: BretasArthur1/sbpf-linker
+          ref: downstream-consumer
           path: sbpf-linker
 
       - uses: dtolnay/rust-toolchain@master
@@ -81,7 +82,7 @@ jobs:
           done
           {
             echo ""
-            echo "[patch.crates-io]"
+            echo '[patch."https://github.com/blueshift-gg/sbpf.git"]'
             echo "sbpf-assembler = { path = \"../crates/assembler\" }"
             echo "sbpf-common = { path = \"../crates/common\" }"
           } >> Cargo.toml
@@ -96,7 +97,7 @@ jobs:
             exit 1
           fi
           if echo "${tree}" | grep -v "(/"; then
-            echo "::error::sbpf crates still resolve to crates.io — the [patch] was discarded"
+          echo "::error::sbpf crates do not resolve to local paths — the [patch] was not applied"
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ Feel free to directly [open a PR](https://github.com/blueshift-gg/sbpf/compare).
 
 [sbpf-linker](https://github.com/blueshift-gg/sbpf-linker) is a downstream consumer of the sbpf API. It relinks BPF binaries into it's sbpf compatible form, so changes to this repository must account for compatibility with the linker.
 
-The [downstream CI job](https://github.com/blueshift-gg/sbpf/blob/master/.github/workflows/downstream-sbpf-linker.yml) runs when your changes touch code consumed by sbpf-linker. If it detects a compatibility break, you’ll need to submit a PR to sbpf-linker porting the changes, to do that you'll follow this flow:
+The [downstream CI job](https://github.com/blueshift-gg/sbpf/blob/master/.github/workflows/downstream-sbpf-linker.yml) runs on every PR to detect if a compatibility break was introduced. If so, you’ll need to submit a PR to sbpf-linker porting the changes, to do that you'll follow this flow:
 
-1. Clone sbpf-linker and create a feature branch based on the [downstream-consumer branch](https://github.com/BretasArthur1/sbpf-linker/tree/downstream-consumer).
-2. Update both [sbpf dependencies](https://github.com/BretasArthur1/sbpf-linker/blob/61f8f934f8cda1ef35efe223cf95f1d9b9d927e9/Cargo.toml#L18-L19) to point to your sbpf commit.
+1. Clone sbpf-linker and create a feature branch based on the [downstream gate branch](https://github.com/blueshift-gg/sbpf-linker/tree/sbpf-linker-next).
+2. Update both [sbpf dependencies](https://github.com/blueshift-gg/sbpf-linker/blob/8edec876120bcc3e0679d5636b724ddd994df1cc/Cargo.toml#L18-L19) to point to your sbpf crates version (you can also specify a commit with rev tag).
 3. Adapt the linker to your changes and verify that its tests pass.
 4. Open a companion PR and link it from your sbpf PR so maintainers can coordinate merging both.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,14 @@ For minor bugs that are solvable in a single-issue PR, feel free to immediately 
 
 ## Nits/Typos
 Feel free to directly [open a PR](https://github.com/blueshift-gg/sbpf/compare).
+
+## Compatibility with sbpf-linker
+
+[sbpf-linker](https://github.com/blueshift-gg/sbpf-linker) is a downstream consumer of the sbpf API. It relinks BPF binaries into it's sbpf compatible form, so changes to this repository must account for compatibility with the linker.
+
+The [downstream CI job](https://github.com/blueshift-gg/sbpf/blob/master/.github/workflows/downstream-sbpf-linker.yml) runs when your changes touch code consumed by sbpf-linker. If it detects a compatibility break, you’ll need to submit a PR to sbpf-linker porting the changes, to do that you'll follow this flow:
+
+1. Clone sbpf-linker and create a feature branch based on the [downstream-consumer branch](https://github.com/BretasArthur1/sbpf-linker/tree/downstream-consumer).
+2. Update both [sbpf dependencies](https://github.com/BretasArthur1/sbpf-linker/blob/61f8f934f8cda1ef35efe223cf95f1d9b9d927e9/Cargo.toml#L18-L19) to point to your sbpf commit.
+3. Adapt the linker to your changes and verify that its tests pass.
+4. Open a companion PR and link it from your sbpf PR so maintainers can coordinate merging both.


### PR DESCRIPTION
## Description
Adds a downstream workflow that builds and tests `sbpf-linker` at its default branch HEAD against the sbpf crates, so API breakage in the crates the linker consumes is caught in CI here, before a release is published.

### How it works

1. Checks out `sbpf-linker` default branch HEAD next to this repo.
2. Rewrites its `sbpf-assembler`/`sbpf-common` requirements to `=<workspace
   version>` and appends `[patch.crates-io]` entries pointing at `crates/assembler` / `crates/common`.
3. Verifies the patch took effect via `cargo tree`, the job fails if either crate still resolves to the registry, so the silent fallback can never produce a false green.
4. Runs the linker's full test suite (compiletest + FileCheck over `tests/assembly/*.rs`), which exercises the assembler/common APIs e2e. Transitive workspace crates (`sbpf-transform`, `sbpf-ir`, `sbpf-syscall-map`) are verified  along via the workspace's path deps.
   
### Disclaimer
The job will fail cause currently `sbpf-linker` pins the published `sbpf-assembler`/`sbpf-common` (currently`0.1.9`) while this workspace is at `0.2.2`. Once we bump the dependencies it will be working and ready to merge.

