### PR TITLE
unit tests added for runtime, cpi, and syscalls

### DIFF
--- a/crates/runtime/src/cpi/builtins/mod.rs
+++ b/crates/runtime/src/cpi/builtins/mod.rs
@@ -33,3 +33,37 @@ pub fn execute_builtin(
         )))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(seed: u8) -> Address {
+        Address::new_from_array([seed; 32])
+    }
+
+    #[test]
+    fn is_builtin_recognizes_system_program() {
+        assert!(is_builtin(&SYSTEM_PROGRAM_ID));
+    }
+
+    #[test]
+    fn is_builtin_rejects_other_programs() {
+        assert!(!is_builtin(&addr(9)));
+    }
+
+    #[test]
+    fn execute_builtin_rejects_unsupported_program() {
+        let mut accounts: HashMap<Address, Account> = HashMap::new();
+        let request = CpiRequest {
+            program_id: addr(9),
+            accounts: Vec::new(),
+            data: Vec::new(),
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+        let err = execute_builtin(&addr(9), &mut accounts, &request, &[], 200_000).unwrap_err();
+        assert!(matches!(err, RuntimeError::BuiltinError(_)));
+        assert!(err.to_string().contains("unsupported builtin program"));
+    }
+}

--- a/crates/runtime/src/cpi/builtins/system.rs
+++ b/crates/runtime/src/cpi/builtins/system.rs
@@ -556,4 +556,320 @@ mod tests {
         let err = process(&mut accounts, &request, &[from], 10).unwrap_err();
         assert!(err.to_string().contains("insufficient compute units"));
     }
+
+    #[test]
+    fn test_invalid_instruction_data() {
+        let mut accounts: HashMap<Address, Account> = HashMap::new();
+        let request = CpiRequest {
+            program_id: system_program::ID,
+            accounts: vec![],
+            data: vec![0xff, 0xff, 0xff, 0xff, 0xff],
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+        let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("invalid system instruction data"));
+    }
+
+    #[test]
+    fn test_not_enough_accounts() {
+        let from = addr(1);
+        let mut accounts = HashMap::from([(from, make_account(1_000_000))]);
+        let request = make_request(
+            vec![meta(from, true, true)],
+            &SystemInstruction::Transfer { lamports: 100 },
+        );
+        let err = process(&mut accounts, &request, &[from], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("not enough account keys"));
+    }
+
+    #[test]
+    fn test_nonce_instruction_is_accepted_as_noop() {
+        let mut accounts: HashMap<Address, Account> = HashMap::new();
+        let request = make_request(vec![], &SystemInstruction::AdvanceNonceAccount);
+        let cu = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap();
+        assert_eq!(cu, SYSTEM_PROGRAM_COMPUTE_UNITS);
+        assert!(accounts.is_empty());
+    }
+
+    #[test]
+    fn test_transfer_from_missing_account() {
+        let from = addr(1);
+        let to = addr(2);
+        let mut accounts = HashMap::from([(to, make_account(0))]);
+        let request = make_request(
+            vec![meta(from, true, true), meta(to, false, true)],
+            &SystemInstruction::Transfer { lamports: 100 },
+        );
+        let err = process(&mut accounts, &request, &[from], COMPUTE_BUDGET).unwrap_err();
+        assert!(matches!(err, RuntimeError::MissingAccount(_)));
+    }
+
+    #[test]
+    fn test_transfer_to_missing_account() {
+        let from = addr(1);
+        let to = addr(2);
+        let mut accounts = HashMap::from([(from, make_account(1_000_000))]);
+        let request = make_request(
+            vec![meta(from, true, true), meta(to, false, true)],
+            &SystemInstruction::Transfer { lamports: 100 },
+        );
+        let err = process(&mut accounts, &request, &[from], COMPUTE_BUDGET).unwrap_err();
+        assert!(matches!(err, RuntimeError::MissingAccount(_)));
+    }
+
+    #[test]
+    fn test_transfer_from_carries_data() {
+        let from = addr(1);
+        let to = addr(2);
+        let mut from_acc = make_account(1_000_000);
+        from_acc.data = vec![1, 2, 3];
+        let mut accounts = HashMap::from([(from, from_acc), (to, make_account(0))]);
+        let request = make_request(
+            vec![meta(from, true, true), meta(to, false, true)],
+            &SystemInstruction::Transfer { lamports: 100 },
+        );
+        let err = process(&mut accounts, &request, &[from], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("from account carries data"));
+    }
+
+    #[test]
+    fn test_transfer_signer_via_derived_signers() {
+        let from = addr(1);
+        let to = addr(2);
+        let mut accounts = HashMap::from([(from, make_account(1_000_000)), (to, make_account(0))]);
+        let request = make_request(
+            vec![meta(from, false, true), meta(to, false, true)],
+            &SystemInstruction::Transfer { lamports: 500_000 },
+        );
+        process(&mut accounts, &request, &[from], COMPUTE_BUDGET).unwrap();
+        assert_eq!(accounts[&from].lamports, 500_000);
+        assert_eq!(accounts[&to].lamports, 500_000);
+    }
+
+    #[test]
+    fn test_create_account_already_in_use() {
+        let payer = addr(1);
+        let new_account = addr(2);
+        let owner = addr(3);
+        let mut accounts = HashMap::from([
+            (payer, make_account(1_000_000)),
+            (new_account, make_account(42)),
+        ]);
+        let request = make_request(
+            vec![meta(payer, true, true), meta(new_account, true, true)],
+            &SystemInstruction::CreateAccount {
+                lamports: 100_000,
+                space: 128,
+                owner,
+            },
+        );
+        let err = process(&mut accounts, &request, &[payer, new_account], COMPUTE_BUDGET)
+            .unwrap_err();
+        assert!(err.to_string().contains("account already in use"));
+    }
+
+    #[test]
+    fn test_assign_already_owned() {
+        let account_key = addr(1);
+        let mut accounts = HashMap::from([(account_key, make_account(0))]);
+        let request = make_request(
+            vec![meta(account_key, false, true)],
+            &SystemInstruction::Assign {
+                owner: system_program::ID,
+            },
+        );
+        process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap();
+        assert_eq!(accounts[&account_key].owner, system_program::ID);
+    }
+
+    #[test]
+    fn test_assign_missing_signer() {
+        let account_key = addr(1);
+        let new_owner = addr(2);
+        let mut accounts = HashMap::from([(account_key, make_account(0))]);
+        let request = make_request(
+            vec![meta(account_key, false, true)],
+            &SystemInstruction::Assign { owner: new_owner },
+        );
+        let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("missing required signature for assign"));
+    }
+
+    #[test]
+    fn test_allocate_missing_signer() {
+        let account_key = addr(1);
+        let mut accounts = HashMap::from([(account_key, make_account(0))]);
+        let request = make_request(
+            vec![meta(account_key, false, true)],
+            &SystemInstruction::Allocate { space: 64 },
+        );
+        let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("missing required signature for allocate"));
+    }
+
+    #[test]
+    fn test_allocate_exceeds_max_length() {
+        let account_key = addr(1);
+        let mut accounts = HashMap::from([(account_key, make_account(0))]);
+        let request = make_request(
+            vec![meta(account_key, true, true)],
+            &SystemInstruction::Allocate {
+                space: MAX_PERMITTED_DATA_LENGTH + 1,
+            },
+        );
+        let err = process(&mut accounts, &request, &[account_key], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("exceeds max length"));
+    }
+
+    #[test]
+    fn test_create_account_with_seed() {
+        let payer = addr(1);
+        let base = addr(4);
+        let owner = addr(3);
+        let seed = "vault";
+        let derived = Address::create_with_seed(&base, seed, &owner).unwrap();
+        let mut accounts = HashMap::from([
+            (payer, make_account(1_000_000)),
+            (derived, make_account(0)),
+        ]);
+        let request = make_request(
+            vec![meta(payer, true, true), meta(derived, false, true)],
+            &SystemInstruction::CreateAccountWithSeed {
+                base,
+                seed: seed.to_string(),
+                lamports: 100_000,
+                space: 64,
+                owner,
+            },
+        );
+        process(&mut accounts, &request, &[payer, base], COMPUTE_BUDGET).unwrap();
+        assert_eq!(accounts[&payer].lamports, 900_000);
+        assert_eq!(accounts[&derived].lamports, 100_000);
+        assert_eq!(accounts[&derived].data.len(), 64);
+        assert_eq!(accounts[&derived].owner, owner);
+    }
+
+    #[test]
+    fn test_create_account_with_seed_mismatch() {
+        let payer = addr(1);
+        let base = addr(4);
+        let owner = addr(3);
+        let wrong = addr(9);
+        let mut accounts = HashMap::from([
+            (payer, make_account(1_000_000)),
+            (wrong, make_account(0)),
+        ]);
+        let request = make_request(
+            vec![meta(payer, true, true), meta(wrong, false, true)],
+            &SystemInstruction::CreateAccountWithSeed {
+                base,
+                seed: "vault".to_string(),
+                lamports: 100_000,
+                space: 64,
+                owner,
+            },
+        );
+        let err = process(&mut accounts, &request, &[payer, base], COMPUTE_BUDGET).unwrap_err();
+        assert!(err.to_string().contains("address with seed mismatch"));
+    }
+
+    #[test]
+    fn test_transfer_with_seed() {
+        let base = addr(4);
+        let from_owner = addr(5);
+        let to = addr(2);
+        let seed = "wallet";
+        let from = Address::create_with_seed(&base, seed, &from_owner).unwrap();
+        let mut accounts = HashMap::from([
+            (from, make_account(1_000_000)),
+            (base, make_account(0)),
+            (to, make_account(0)),
+        ]);
+        let request = make_request(
+            vec![
+                meta(from, false, true),
+                meta(base, true, true),
+                meta(to, false, true),
+            ],
+            &SystemInstruction::TransferWithSeed {
+                lamports: 400_000,
+                from_seed: seed.to_string(),
+                from_owner,
+            },
+        );
+        process(&mut accounts, &request, &[base], COMPUTE_BUDGET).unwrap();
+        assert_eq!(accounts[&from].lamports, 600_000);
+        assert_eq!(accounts[&to].lamports, 400_000);
+    }
+
+    #[test]
+    fn test_transfer_with_seed_missing_signer() {
+        let base = addr(4);
+        let from_owner = addr(5);
+        let to = addr(2);
+        let seed = "wallet";
+        let from = Address::create_with_seed(&base, seed, &from_owner).unwrap();
+        let mut accounts = HashMap::from([
+            (from, make_account(1_000_000)),
+            (base, make_account(0)),
+            (to, make_account(0)),
+        ]);
+        let request = make_request(
+            vec![
+                meta(from, false, true),
+                meta(base, false, true),
+                meta(to, false, true),
+            ],
+            &SystemInstruction::TransferWithSeed {
+                lamports: 400_000,
+                from_seed: seed.to_string(),
+                from_owner,
+            },
+        );
+        let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("missing required signature for transfer_with_seed"));
+    }
+
+    #[test]
+    fn test_assign_with_seed() {
+        let base = addr(4);
+        let owner = addr(3);
+        let seed = "state";
+        let account_key = Address::create_with_seed(&base, seed, &owner).unwrap();
+        let mut accounts = HashMap::from([(account_key, make_account(0))]);
+        let request = make_request(
+            vec![meta(account_key, false, true)],
+            &SystemInstruction::AssignWithSeed {
+                base,
+                seed: seed.to_string(),
+                owner,
+            },
+        );
+        process(&mut accounts, &request, &[base], COMPUTE_BUDGET).unwrap();
+        assert_eq!(accounts[&account_key].owner, owner);
+    }
+
+    #[test]
+    fn test_allocate_with_seed() {
+        let base = addr(4);
+        let owner = addr(3);
+        let seed = "data";
+        let account_key = Address::create_with_seed(&base, seed, &owner).unwrap();
+        let mut accounts = HashMap::from([(account_key, make_account(0))]);
+        let request = make_request(
+            vec![meta(account_key, false, true)],
+            &SystemInstruction::AllocateWithSeed {
+                base,
+                seed: seed.to_string(),
+                space: 96,
+                owner,
+            },
+        );
+        process(&mut accounts, &request, &[base], COMPUTE_BUDGET).unwrap();
+        assert_eq!(accounts[&account_key].data.len(), 96);
+        assert_eq!(accounts[&account_key].owner, owner);
+    }
 }

--- a/crates/runtime/src/cpi/builtins/system.rs
+++ b/crates/runtime/src/cpi/builtins/system.rs
@@ -664,8 +664,13 @@ mod tests {
                 owner,
             },
         );
-        let err = process(&mut accounts, &request, &[payer, new_account], COMPUTE_BUDGET)
-            .unwrap_err();
+        let err = process(
+            &mut accounts,
+            &request,
+            &[payer, new_account],
+            COMPUTE_BUDGET,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("account already in use"));
     }
 
@@ -693,7 +698,10 @@ mod tests {
             &SystemInstruction::Assign { owner: new_owner },
         );
         let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
-        assert!(err.to_string().contains("missing required signature for assign"));
+        assert!(
+            err.to_string()
+                .contains("missing required signature for assign")
+        );
     }
 
     #[test]
@@ -705,7 +713,10 @@ mod tests {
             &SystemInstruction::Allocate { space: 64 },
         );
         let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
-        assert!(err.to_string().contains("missing required signature for allocate"));
+        assert!(
+            err.to_string()
+                .contains("missing required signature for allocate")
+        );
     }
 
     #[test]
@@ -729,10 +740,8 @@ mod tests {
         let owner = addr(3);
         let seed = "vault";
         let derived = Address::create_with_seed(&base, seed, &owner).unwrap();
-        let mut accounts = HashMap::from([
-            (payer, make_account(1_000_000)),
-            (derived, make_account(0)),
-        ]);
+        let mut accounts =
+            HashMap::from([(payer, make_account(1_000_000)), (derived, make_account(0))]);
         let request = make_request(
             vec![meta(payer, true, true), meta(derived, false, true)],
             &SystemInstruction::CreateAccountWithSeed {
@@ -756,10 +765,8 @@ mod tests {
         let base = addr(4);
         let owner = addr(3);
         let wrong = addr(9);
-        let mut accounts = HashMap::from([
-            (payer, make_account(1_000_000)),
-            (wrong, make_account(0)),
-        ]);
+        let mut accounts =
+            HashMap::from([(payer, make_account(1_000_000)), (wrong, make_account(0))]);
         let request = make_request(
             vec![meta(payer, true, true), meta(wrong, false, true)],
             &SystemInstruction::CreateAccountWithSeed {
@@ -828,9 +835,10 @@ mod tests {
             },
         );
         let err = process(&mut accounts, &request, &[], COMPUTE_BUDGET).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("missing required signature for transfer_with_seed"));
+        assert!(
+            err.to_string()
+                .contains("missing required signature for transfer_with_seed")
+        );
     }
 
     #[test]

--- a/crates/runtime/src/cpi/mod.rs
+++ b/crates/runtime/src/cpi/mod.rs
@@ -251,3 +251,164 @@ fn execute_elf_cpi(ctx: &mut CpiContext) -> CpiExecResult {
         compute_consumed: consumed,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::cpi::request::CpiAccountMeta,
+        solana_system_interface::{instruction::SystemInstruction, program as system_program},
+        std::{cell::RefCell, rc::Rc},
+    };
+
+    fn addr(seed: u8) -> Address {
+        Address::new_from_array([seed; 32])
+    }
+
+    fn log_collector() -> LogCollector {
+        Rc::new(RefCell::new(Vec::new()))
+    }
+
+    fn system_account(lamports: u64) -> Account {
+        Account {
+            lamports,
+            data: vec![],
+            owner: system_program::ID,
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    #[test]
+    fn execute_cpi_program_not_found() {
+        let config = RuntimeConfig::default();
+        let sysvars = SysvarContext::default();
+        let programs: HashMap<Address, Vec<u8>> = HashMap::new();
+        let mut accounts: HashMap<Address, Account> = HashMap::new();
+        let logs = log_collector();
+
+        // Non-builtin program that was never registered via add_program.
+        let request = CpiRequest {
+            program_id: addr(9),
+            accounts: Vec::new(),
+            data: Vec::new(),
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+        let mut ctx = CpiContext {
+            request,
+            programs: &programs,
+            accounts: &mut accounts,
+            config: &config,
+            sysvars: &sysvars,
+            compute_remaining: 200_000,
+            cpi_depth: 0,
+            caller_account_metas: &[],
+            log_collector: &logs,
+        };
+
+        match execute_cpi(&mut ctx) {
+            Err(RuntimeError::ProgramNotFound(_)) => {}
+            Err(other) => panic!("expected ProgramNotFound, got {other:?}"),
+            Ok(_) => panic!("expected ProgramNotFound error"),
+        }
+    }
+
+    #[test]
+    fn execute_cpi_depth_exceeded() {
+        let config = RuntimeConfig::default();
+        let sysvars = SysvarContext::default();
+        let programs: HashMap<Address, Vec<u8>> = HashMap::new();
+        let mut accounts: HashMap<Address, Account> = HashMap::new();
+        let logs = log_collector();
+
+        let request = CpiRequest {
+            program_id: addr(9),
+            accounts: Vec::new(),
+            data: Vec::new(),
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+        let mut ctx = CpiContext {
+            request,
+            programs: &programs,
+            accounts: &mut accounts,
+            config: &config,
+            sysvars: &sysvars,
+            compute_remaining: 200_000,
+            cpi_depth: config.max_cpi_depth, // already at the limit
+            caller_account_metas: &[],
+            log_collector: &logs,
+        };
+
+        match execute_cpi(&mut ctx) {
+            Err(RuntimeError::CpiDepthExceeded(_)) => {}
+            Err(other) => panic!("expected CpiDepthExceeded, got {other:?}"),
+            Ok(_) => panic!("expected CpiDepthExceeded error"),
+        }
+    }
+
+    #[test]
+    fn execute_cpi_dispatches_system_transfer_builtin() {
+        let config = RuntimeConfig::default();
+        let sysvars = SysvarContext::default();
+        let programs: HashMap<Address, Vec<u8>> = HashMap::new();
+        let logs = log_collector();
+
+        let from = addr(1);
+        let to = addr(2);
+        let mut accounts =
+            HashMap::from([(from, system_account(1_000_000)), (to, system_account(0))]);
+
+        let request = CpiRequest {
+            program_id: system_program::ID,
+            accounts: vec![
+                CpiAccountMeta {
+                    pubkey: from,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                CpiAccountMeta {
+                    pubkey: to,
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ],
+            data: bincode::serialize(&SystemInstruction::Transfer { lamports: 400_000 }).unwrap(),
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+
+        let caller_metas = vec![
+            AccountMeta {
+                pubkey: from,
+                is_signer: true,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: to,
+                is_signer: false,
+                is_writable: true,
+            },
+        ];
+
+        let mut ctx = CpiContext {
+            request,
+            programs: &programs,
+            accounts: &mut accounts,
+            config: &config,
+            sysvars: &sysvars,
+            compute_remaining: 200_000,
+            cpi_depth: 0,
+            caller_account_metas: &caller_metas,
+            log_collector: &logs,
+        };
+
+        let output = execute_cpi(&mut ctx).unwrap();
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(accounts[&from].lamports, 600_000);
+        assert_eq!(accounts[&to].lamports, 400_000);
+        assert!(logs.borrow().iter().any(|l| l.contains("invoke [1]")));
+        assert!(logs.borrow().iter().any(|l| l.contains("success")));
+    }
+}

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -477,3 +477,192 @@ impl Runtime {
         self.log_collector.borrow_mut().drain(..).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::path::PathBuf,
+    };
+
+    const PROGRAM_ID: Address =
+        Address::from_str_const("22222222222222222222222222222222222222222222");
+
+    fn escrow_elf_path() -> String {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/libupstream_pinocchio_escrow.so")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn new_runtime() -> Runtime {
+        Runtime::new(PROGRAM_ID, escrow_elf_path().as_str(), RuntimeConfig::default()).unwrap()
+    }
+
+    fn empty_instruction() -> SolanaInstruction {
+        SolanaInstruction {
+            program_id: PROGRAM_ID,
+            accounts: Vec::new(),
+            data: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn elf_source_from_str() {
+        let path = escrow_elf_path();
+        assert!(matches!(ElfSource::from(path.as_str()), ElfSource::Path(_)));
+    }
+
+    #[test]
+    fn elf_source_from_bytes_slice() {
+        let bytes: &[u8] = &[1, 2, 3];
+        assert!(matches!(ElfSource::from(bytes), ElfSource::Bytes(_)));
+    }
+
+    #[test]
+    fn elf_source_from_vec() {
+        assert!(matches!(ElfSource::from(vec![1u8, 2, 3]), ElfSource::Bytes(_)));
+    }
+
+    #[test]
+    fn new_from_path() {
+        let rt = new_runtime();
+        assert_eq!(*rt.current_program_id(), PROGRAM_ID);
+        assert!(!rt.get_program().is_empty());
+    }
+
+    #[test]
+    fn new_from_bytes() {
+        let bytes = std::fs::read(escrow_elf_path()).unwrap();
+        let rt = Runtime::new(PROGRAM_ID, bytes, RuntimeConfig::default()).unwrap();
+        assert!(!rt.get_program().is_empty());
+    }
+
+    #[test]
+    fn new_bad_path_errors() {
+        match Runtime::new(
+            PROGRAM_ID,
+            "/nonexistent/path/to/program.so",
+            RuntimeConfig::default(),
+        ) {
+            Err(RuntimeError::ElfReadError(_)) => {}
+            other => panic!("expected ElfReadError, got {:?}", other.map(|_| ())),
+        }
+    }
+
+    #[test]
+    fn new_invalid_elf_errors() {
+        match Runtime::new(PROGRAM_ID, vec![0u8; 8], RuntimeConfig::default()) {
+            Err(RuntimeError::ElfReadError(_)) => panic!("expected parse error, got io error"),
+            Err(_) => {}
+            Ok(_) => panic!("expected error for invalid ELF"),
+        }
+    }
+
+    #[test]
+    fn add_program_accepts_path_and_bytes() {
+        let mut rt = new_runtime();
+        rt.add_program(&Address::new_unique(), escrow_elf_path().as_str());
+        let bytes = std::fs::read(escrow_elf_path()).unwrap();
+        rt.add_program(&Address::new_unique(), bytes);
+    }
+
+    #[test]
+    fn getters_before_prepare_are_defaults() {
+        let rt = new_runtime();
+        assert_eq!(rt.get_pc(), 0);
+        assert!(rt.get_registers().is_none());
+        assert!(rt.get_register(2).is_none());
+        assert!(rt.read_memory(Memory::INPUT_START, 8).is_none());
+        assert!(rt.get_instruction().is_none());
+        assert!(rt.get_call_stack().is_none());
+        assert!(!rt.is_halted());
+        assert!(rt.exit_code().is_none());
+        assert_eq!(rt.compute_units_consumed(), 0);
+        assert!(rt.get_account(&PROGRAM_ID).is_none());
+        assert!(rt.get_accounts().is_empty());
+        assert!(rt.drain_logs().is_empty());
+    }
+
+    #[test]
+    fn set_register_before_prepare_errors() {
+        let mut rt = new_runtime();
+        let err = rt.set_register(0, 42).unwrap_err();
+        assert!(matches!(err, RuntimeError::VmNotPrepared));
+    }
+
+    #[test]
+    fn step_before_prepare_errors() {
+        let mut rt = new_runtime();
+        let err = rt.step().unwrap_err();
+        assert!(matches!(err, RuntimeError::VmNotPrepared));
+    }
+
+    #[test]
+    fn config_and_sysvar_accessors() {
+        let mut rt = new_runtime();
+        assert_eq!(rt.config().compute_budget, RuntimeConfig::default().compute_budget);
+        let slot = rt.sysvars().clock.slot;
+        rt.sysvars_mut().clock.slot = slot + 5;
+        assert_eq!(rt.sysvars().clock.slot, slot + 5);
+        assert!(rt.log_collector().borrow().is_empty());
+    }
+
+    #[test]
+    fn prepare_initializes_vm_state() {
+        let mut rt = new_runtime();
+        rt.prepare(&empty_instruction(), &[]).unwrap();
+
+        // After prepare the VM exists: getters now return Some / live values.
+        assert!(rt.get_registers().is_some());
+        assert!(rt.get_call_stack().is_some());
+        assert!(rt.get_instruction().is_some());
+        let r2 = rt.get_register(2).unwrap();
+        assert!(r2 >= Memory::INPUT_START);
+        assert!(rt.read_memory(Memory::INPUT_START, 8).is_some());
+        let logs = rt.log_collector().borrow().clone();
+        assert!(logs.iter().any(|l| l.contains("invoke [1]")));
+    }
+
+    #[test]
+    fn set_register_after_prepare_and_out_of_range() {
+        let mut rt = new_runtime();
+        rt.prepare(&empty_instruction(), &[]).unwrap();
+
+        rt.set_register(3, 0xdead_beef).unwrap();
+        assert_eq!(rt.get_register(3), Some(0xdead_beef));
+
+        let err = rt.set_register(99, 1).unwrap_err();
+        assert!(matches!(err, RuntimeError::RegisterOutOfRange(99)));
+    }
+
+    #[test]
+    fn step_drives_program_to_clean_halt() {
+        let mut rt = new_runtime();
+        rt.prepare(&empty_instruction(), &[]).unwrap();
+
+        let mut steps = 0;
+        while !rt.is_halted() {
+            rt.step().expect("step should not trap on this program");
+            steps += 1;
+            assert!(steps <= 100_000, "program did not terminate");
+        }
+        assert!(steps > 0);
+        assert!(rt.is_halted());
+        assert!(rt.exit_code().is_some());
+    }
+
+    #[test]
+    fn run_returns_ok_with_nonzero_exit_and_logs() {
+        let mut rt = new_runtime();
+        let exec = rt.run(&empty_instruction(), &[]).unwrap();
+
+        assert!(matches!(exec.exit_code, Some(code) if code != 0));
+        assert!(exec.compute_units_consumed > 0);
+
+        assert!(exec.logs.iter().any(|l| l.contains("invoke [1]")));
+        assert!(exec.logs.iter().any(|l| l.contains("consumed")));
+        assert!(exec.logs.iter().any(|l| l.contains("failed: exit code")));
+    }
+}

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -480,10 +480,7 @@ impl Runtime {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        std::path::PathBuf,
-    };
+    use {super::*, std::path::PathBuf};
 
     const PROGRAM_ID: Address =
         Address::from_str_const("22222222222222222222222222222222222222222222");
@@ -497,7 +494,12 @@ mod tests {
     }
 
     fn new_runtime() -> Runtime {
-        Runtime::new(PROGRAM_ID, escrow_elf_path().as_str(), RuntimeConfig::default()).unwrap()
+        Runtime::new(
+            PROGRAM_ID,
+            escrow_elf_path().as_str(),
+            RuntimeConfig::default(),
+        )
+        .unwrap()
     }
 
     fn empty_instruction() -> SolanaInstruction {
@@ -522,7 +524,10 @@ mod tests {
 
     #[test]
     fn elf_source_from_vec() {
-        assert!(matches!(ElfSource::from(vec![1u8, 2, 3]), ElfSource::Bytes(_)));
+        assert!(matches!(
+            ElfSource::from(vec![1u8, 2, 3]),
+            ElfSource::Bytes(_)
+        ));
     }
 
     #[test]
@@ -602,7 +607,10 @@ mod tests {
     #[test]
     fn config_and_sysvar_accessors() {
         let mut rt = new_runtime();
-        assert_eq!(rt.config().compute_budget, RuntimeConfig::default().compute_budget);
+        assert_eq!(
+            rt.config().compute_budget,
+            RuntimeConfig::default().compute_budget
+        );
         let slot = rt.sysvars().clock.slot;
         rt.sysvars_mut().clock.slot = slot + 5;
         assert_eq!(rt.sysvars().clock.slot, slot + 5);

--- a/crates/runtime/src/syscalls/abort.rs
+++ b/crates/runtime/src/syscalls/abort.rs
@@ -17,3 +17,48 @@ pub fn sol_panic(registers: [u64; 5], memory: &mut Memory) -> SbpfVmResult<u64> 
     eprintln!("Program panicked at {}:{}:{}", file, line, column);
     Err(SbpfVmError::Abort)
 }
+
+#[cfg(test)]
+mod tests {
+    use {super::*, sbpf_vm::memory::Memory};
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 4096)
+    }
+
+    #[test]
+    fn test_abort_returns_abort_error() {
+        assert!(matches!(abort(), Err(SbpfVmError::Abort)));
+    }
+
+    #[test]
+    fn test_sol_panic_returns_abort() {
+        let mut memory = make_memory();
+        let file = b"src/main.rs";
+        memory.write_bytes(Memory::HEAP_START, file).unwrap();
+        let registers = [Memory::HEAP_START, file.len() as u64, 42, 7, 0];
+        assert!(matches!(
+            sol_panic(registers, &mut memory),
+            Err(SbpfVmError::Abort)
+        ));
+    }
+
+    #[test]
+    fn test_sol_panic_oob_file_ptr_returns_error() {
+        let mut memory = make_memory();
+        let registers = [0xDEAD_0000_0000, 10, 1, 1, 0];
+        let result = sol_panic(registers, &mut memory);
+        assert!(result.is_err());
+        assert!(!matches!(result, Err(SbpfVmError::Abort)));
+    }
+
+    #[test]
+    fn test_sol_panic_zero_length_file() {
+        let mut memory = make_memory();
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        assert!(matches!(
+            sol_panic(registers, &mut memory),
+            Err(SbpfVmError::Abort)
+        ));
+    }
+}

--- a/crates/runtime/src/syscalls/abort.rs
+++ b/crates/runtime/src/syscalls/abort.rs
@@ -20,11 +20,7 @@ pub fn sol_panic(registers: [u64; 5], memory: &mut Memory) -> SbpfVmResult<u64> 
 
 #[cfg(test)]
 mod tests {
-    use {super::*, sbpf_vm::memory::Memory};
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 4096)
-    }
+    use {super::*, crate::syscalls::tests::test_helpers::make_memory, sbpf_vm::memory::Memory};
 
     #[test]
     fn test_abort_returns_abort_error() {

--- a/crates/runtime/src/syscalls/crypto.rs
+++ b/crates/runtime/src/syscalls/crypto.rs
@@ -144,20 +144,9 @@ pub fn sol_blake3(
 mod tests {
     use {
         super::*,
-        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        crate::syscalls::tests::test_helpers::{costs, make_memory, meter},
+        sbpf_vm::{errors::SbpfVmError, memory::Memory},
     };
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 64 * 1024)
-    }
-
-    fn costs() -> ExecutionCost {
-        ExecutionCost::default()
-    }
-
-    fn meter(limit: u64) -> ComputeMeter {
-        ComputeMeter::new(limit)
-    }
 
     fn setup_single_slice(memory: &mut Memory, data: &[u8]) -> (u64, u64) {
         let data_addr = Memory::HEAP_START;

--- a/crates/runtime/src/syscalls/crypto.rs
+++ b/crates/runtime/src/syscalls/crypto.rs
@@ -139,3 +139,198 @@ pub fn sol_blake3(
         registers[2],
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+    };
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 64 * 1024)
+    }
+
+    fn costs() -> ExecutionCost {
+        ExecutionCost::default()
+    }
+
+    fn meter(limit: u64) -> ComputeMeter {
+        ComputeMeter::new(limit)
+    }
+
+    fn setup_single_slice(memory: &mut Memory, data: &[u8]) -> (u64, u64) {
+        let data_addr = Memory::HEAP_START;
+        memory.write_bytes(data_addr, data).unwrap();
+
+        let slices_addr = Memory::HEAP_START + 64;
+        memory.write_u64(slices_addr, data_addr).unwrap();
+        memory
+            .write_u64(slices_addr + 8, data.len() as u64)
+            .unwrap();
+
+        let result_addr = Memory::HEAP_START + 128;
+        (slices_addr, result_addr)
+    }
+
+    fn reference_sha256(data: &[u8]) -> Vec<u8> {
+        use sha2::Digest;
+        sha2::Sha256::digest(data).to_vec()
+    }
+
+    fn reference_keccak256(data: &[u8]) -> Vec<u8> {
+        use sha3::Digest;
+        sha3::Keccak256::digest(data).to_vec()
+    }
+
+    fn reference_blake3(data: &[u8]) -> Vec<u8> {
+        blake3::hash(data).as_bytes().to_vec()
+    }
+
+    #[test]
+    fn test_sha256_known_input() {
+        let mut memory = make_memory();
+        let (slices_addr, result_addr) = setup_single_slice(&mut memory, b"hello");
+
+        let registers = [slices_addr, 1, result_addr, 0, 0];
+        sol_sha256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_sha256(b"hello").as_slice());
+    }
+
+    #[test]
+    fn test_sha256_empty_slices() {
+        let mut memory = make_memory();
+        let result_addr = Memory::HEAP_START + 128;
+
+        let registers = [0, 0, result_addr, 0, 0];
+        sol_sha256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_sha256(b"").as_slice());
+    }
+
+    #[test]
+    fn test_sha256_multiple_slices_concatenated() {
+        let mut memory = make_memory();
+        memory.write_bytes(Memory::HEAP_START, b"he").unwrap();
+        memory.write_bytes(Memory::HEAP_START + 8, b"llo").unwrap();
+
+        let slices_addr = Memory::HEAP_START + 64;
+        memory.write_u64(slices_addr, Memory::HEAP_START).unwrap();
+        memory.write_u64(slices_addr + 8, 2).unwrap();
+        memory
+            .write_u64(slices_addr + 16, Memory::HEAP_START + 8)
+            .unwrap();
+        memory.write_u64(slices_addr + 24, 3).unwrap();
+
+        let result_addr = Memory::HEAP_START + 128;
+        let registers = [slices_addr, 2, result_addr, 0, 0];
+        sol_sha256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_sha256(b"hello").as_slice());
+    }
+
+    #[test]
+    fn test_sha256_too_many_slices() {
+        let mut memory = make_memory();
+        let result_addr = Memory::HEAP_START + 128;
+        let registers = [Memory::HEAP_START, 20_001, result_addr, 0, 0];
+        assert!(matches!(
+            sol_sha256(registers, &mut memory, &meter(1_000_000), &costs()),
+            Err(SbpfVmError::TooManySlices)
+        ));
+    }
+
+    #[test]
+    fn test_sha256_compute_exhausted() {
+        let mut memory = make_memory();
+        let result_addr = Memory::HEAP_START + 128;
+        let registers = [0, 0, result_addr, 0, 0];
+        assert!(matches!(
+            sol_sha256(registers, &mut memory, &meter(84), &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_keccak256_known_input() {
+        let mut memory = make_memory();
+        let (slices_addr, result_addr) = setup_single_slice(&mut memory, b"hello");
+
+        let registers = [slices_addr, 1, result_addr, 0, 0];
+        sol_keccak256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_keccak256(b"hello").as_slice());
+    }
+
+    #[test]
+    fn test_keccak256_empty_slices() {
+        let mut memory = make_memory();
+        let result_addr = Memory::HEAP_START + 128;
+        let registers = [0, 0, result_addr, 0, 0];
+        sol_keccak256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_keccak256(b"").as_slice());
+    }
+
+    #[test]
+    fn test_keccak256_differs_from_sha256() {
+        let mut memory = make_memory();
+        let (slices_addr, result_addr) = setup_single_slice(&mut memory, b"hello");
+
+        let registers = [slices_addr, 1, result_addr, 0, 0];
+        sol_keccak256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let keccak_result = memory.read_bytes(result_addr, 32).unwrap().to_vec();
+        assert_ne!(keccak_result, reference_sha256(b"hello"));
+    }
+
+    #[test]
+    fn test_blake3_known_input() {
+        let mut memory = make_memory();
+        let (slices_addr, result_addr) = setup_single_slice(&mut memory, b"hello");
+
+        let registers = [slices_addr, 1, result_addr, 0, 0];
+        sol_blake3(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_blake3(b"hello").as_slice());
+    }
+
+    #[test]
+    fn test_blake3_empty_slices() {
+        let mut memory = make_memory();
+        let result_addr = Memory::HEAP_START + 128;
+        let registers = [0, 0, result_addr, 0, 0];
+        sol_blake3(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let result = memory.read_bytes(result_addr, 32).unwrap();
+        assert_eq!(result, reference_blake3(b"").as_slice());
+    }
+
+    #[test]
+    fn test_all_three_hashes_differ_on_same_input() {
+        let mut memory = make_memory();
+
+        let (slices_addr, result_addr) = setup_single_slice(&mut memory, b"test");
+        let registers = [slices_addr, 1, result_addr, 0, 0];
+
+        sol_sha256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        let sha_out = memory.read_bytes(result_addr, 32).unwrap().to_vec();
+
+        sol_keccak256(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        let keccak_out = memory.read_bytes(result_addr, 32).unwrap().to_vec();
+
+        sol_blake3(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        let blake_out = memory.read_bytes(result_addr, 32).unwrap().to_vec();
+
+        assert_ne!(sha_out, keccak_out);
+        assert_ne!(sha_out, blake_out);
+        assert_ne!(keccak_out, blake_out);
+    }
+}

--- a/crates/runtime/src/syscalls/log.rs
+++ b/crates/runtime/src/syscalls/log.rs
@@ -79,22 +79,13 @@ pub fn sol_remaining_compute_units(
 mod tests {
     use {
         super::*,
-        crate::{config::ExecutionCost, runtime::LogCollector},
-        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        crate::{
+            runtime::LogCollector,
+            syscalls::tests::test_helpers::{costs, make_memory, meter},
+        },
+        sbpf_vm::{errors::SbpfVmError, memory::Memory},
         std::{cell::RefCell, rc::Rc},
     };
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 4096)
-    }
-
-    fn costs() -> ExecutionCost {
-        ExecutionCost::default()
-    }
-
-    fn meter(limit: u64) -> ComputeMeter {
-        ComputeMeter::new(limit)
-    }
 
     fn new_log() -> LogCollector {
         Rc::new(RefCell::new(Vec::new()))

--- a/crates/runtime/src/syscalls/log.rs
+++ b/crates/runtime/src/syscalls/log.rs
@@ -74,3 +74,156 @@ pub fn sol_remaining_compute_units(
     compute.consume(costs.syscall_base_cost)?;
     Ok(compute.get_remaining())
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{config::ExecutionCost, runtime::LogCollector},
+        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        std::{cell::RefCell, rc::Rc},
+    };
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 4096)
+    }
+
+    fn costs() -> ExecutionCost {
+        ExecutionCost::default()
+    }
+
+    fn meter(limit: u64) -> ComputeMeter {
+        ComputeMeter::new(limit)
+    }
+
+    fn new_log() -> LogCollector {
+        Rc::new(RefCell::new(Vec::new()))
+    }
+
+    #[test]
+    fn test_sol_log_basic() {
+        let mut memory = make_memory();
+        let msg = b"hello world";
+        memory.write_bytes(Memory::HEAP_START, msg).unwrap();
+
+        let log = new_log();
+        let registers = [Memory::HEAP_START, msg.len() as u64, 0, 0, 0];
+        sol_log(registers, &memory, &meter(1_000_000), &costs(), &log).unwrap();
+
+        assert_eq!(log.borrow()[0], "Program log: hello world");
+    }
+
+    #[test]
+    fn test_sol_log_empty_message() {
+        let memory = make_memory();
+        let log = new_log();
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        sol_log(registers, &memory, &meter(1_000_000), &costs(), &log).unwrap();
+
+        assert_eq!(log.borrow()[0], "Program log: ");
+    }
+
+    #[test]
+    fn test_sol_log_invalid_utf8_is_lossy() {
+        let mut memory = make_memory();
+        memory.write_bytes(Memory::HEAP_START, &[0xFF]).unwrap();
+        let log = new_log();
+        let registers = [Memory::HEAP_START, 1, 0, 0, 0];
+        sol_log(registers, &memory, &meter(1_000_000), &costs(), &log).unwrap();
+
+        assert!(log.borrow()[0].starts_with("Program log: "));
+    }
+
+    #[test]
+    fn test_sol_log_compute_exhausted() {
+        let memory = make_memory();
+        let log = new_log();
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        assert!(matches!(
+            sol_log(registers, &memory, &meter(99), &costs(), &log),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sol_log_64_format() {
+        let log = new_log();
+        let registers = [1, 2, 3, 4, 5];
+        sol_log_64(registers, &meter(1_000_000), &costs(), &log).unwrap();
+
+        assert_eq!(log.borrow()[0], "Program log: 0x1, 0x2, 0x3, 0x4, 0x5");
+    }
+
+    #[test]
+    fn test_sol_log_64_zeros() {
+        let log = new_log();
+        sol_log_64([0, 0, 0, 0, 0], &meter(1_000_000), &costs(), &log).unwrap();
+        assert_eq!(log.borrow()[0], "Program log: 0x0, 0x0, 0x0, 0x0, 0x0");
+    }
+
+    #[test]
+    fn test_sol_log_64_compute_exhausted() {
+        let log = new_log();
+        assert!(matches!(
+            sol_log_64([0; 5], &meter(99), &costs(), &log),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sol_log_pubkey_formats_base58() {
+        let mut memory = make_memory();
+        let pubkey = [0u8; 32];
+        memory.write_bytes(Memory::HEAP_START, &pubkey).unwrap();
+
+        let log = new_log();
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        sol_log_pubkey(registers, &memory, &meter(1_000_000), &costs(), &log).unwrap();
+
+        let expected = bs58::encode(&pubkey).into_string();
+        assert_eq!(log.borrow()[0], format!("Program log: {}", expected));
+    }
+
+    #[test]
+    fn test_sol_log_pubkey_nonzero() {
+        let mut memory = make_memory();
+        let mut pubkey = [0u8; 32];
+        pubkey[0] = 1;
+        memory.write_bytes(Memory::HEAP_START, &pubkey).unwrap();
+
+        let log = new_log();
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        sol_log_pubkey(registers, &memory, &meter(1_000_000), &costs(), &log).unwrap();
+
+        let expected = bs58::encode(&pubkey).into_string();
+        assert_eq!(log.borrow()[0], format!("Program log: {}", expected));
+    }
+
+    #[test]
+    fn test_sol_log_compute_units_logs_remaining() {
+        let compute = meter(1_000_000);
+        let log = new_log();
+        sol_log_compute_units(&compute, &costs(), &log).unwrap();
+
+        // After consuming syscall_base_cost=100, remaining = 999_900
+        let msg = &log.borrow()[0];
+        assert!(msg.starts_with("Program consumption:"));
+        assert!(msg.contains("999900 units remaining"));
+    }
+
+    #[test]
+    fn test_sol_remaining_compute_units_returns_remaining() {
+        let compute = meter(1_000);
+        let result = sol_remaining_compute_units(&compute, &costs()).unwrap();
+        assert_eq!(result, 900);
+    }
+
+    #[test]
+    fn test_sol_remaining_compute_units_exhausted() {
+        let compute = meter(50);
+        assert!(matches!(
+            sol_remaining_compute_units(&compute, &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+}

--- a/crates/runtime/src/syscalls/memory.rs
+++ b/crates/runtime/src/syscalls/memory.rs
@@ -109,20 +109,9 @@ pub fn sol_memcmp(
 mod tests {
     use {
         super::*,
-        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        crate::syscalls::tests::test_helpers::{costs, make_memory, meter},
+        sbpf_vm::{errors::SbpfVmError, memory::Memory},
     };
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 64 * 1024)
-    }
-
-    fn costs() -> ExecutionCost {
-        ExecutionCost::default()
-    }
-
-    fn meter(limit: u64) -> ComputeMeter {
-        ComputeMeter::new(limit)
-    }
 
     #[test]
     fn test_memcpy_basic() {

--- a/crates/runtime/src/syscalls/memory.rs
+++ b/crates/runtime/src/syscalls/memory.rs
@@ -104,3 +104,243 @@ pub fn sol_memcmp(
     memory.write_u32(result_ptr, result as u32)?;
     Ok(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+    };
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 64 * 1024)
+    }
+
+    fn costs() -> ExecutionCost {
+        ExecutionCost::default()
+    }
+
+    fn meter(limit: u64) -> ComputeMeter {
+        ComputeMeter::new(limit)
+    }
+
+    #[test]
+    fn test_memcpy_basic() {
+        let mut memory = make_memory();
+        let src = Memory::HEAP_START;
+        let dst = Memory::HEAP_START + 64;
+        memory.write_bytes(src, &[1, 2, 3, 4, 5]).unwrap();
+
+        let registers = [dst, src, 5, 0, 0];
+        sol_memcpy(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        assert_eq!(memory.read_bytes(dst, 5).unwrap(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_memcpy_overlapping_returns_error() {
+        let mut memory = make_memory();
+        // src at HEAP_START, dst 4 bytes into src, n=8 → overlapping
+        let src = Memory::HEAP_START;
+        let dst = Memory::HEAP_START + 4;
+        memory.write_bytes(src, &[0u8; 16]).unwrap();
+
+        let registers = [dst, src, 8, 0, 0];
+        assert!(matches!(
+            sol_memcpy(registers, &mut memory, &meter(1_000_000), &costs()),
+            Err(SbpfVmError::OverlappingMemoryRegions)
+        ));
+    }
+
+    #[test]
+    fn test_memcpy_adjacent_not_overlapping() {
+        let mut memory = make_memory();
+        let src = Memory::HEAP_START;
+        let dst = Memory::HEAP_START + 5;
+        memory.write_bytes(src, &[10, 20, 30, 40, 50]).unwrap();
+
+        let registers = [dst, src, 5, 0, 0];
+        sol_memcpy(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        assert_eq!(memory.read_bytes(dst, 5).unwrap(), &[10, 20, 30, 40, 50]);
+    }
+
+    #[test]
+    fn test_memcpy_zero_length() {
+        let mut memory = make_memory();
+        let src = Memory::HEAP_START;
+        let dst = Memory::HEAP_START + 32;
+        memory.write_bytes(src, &[0xAA]).unwrap();
+
+        let registers = [dst, src, 0, 0, 0];
+        sol_memcpy(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        assert_eq!(memory.read_u8(dst).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_memcpy_compute_exhausted() {
+        let mut memory = make_memory();
+        memory
+            .write_bytes(Memory::HEAP_START, &[1, 2, 3, 4, 5])
+            .unwrap();
+
+        let registers = [Memory::HEAP_START + 64, Memory::HEAP_START, 5, 0, 0];
+        // mem_op_base_cost = 10; budget of 9 is not enough
+        assert!(matches!(
+            sol_memcpy(registers, &mut memory, &meter(9), &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_memcpy_oob_dst() {
+        let mut memory = make_memory();
+        let src = Memory::HEAP_START;
+        let heap_size = 64 * 1024u64;
+        let dst = Memory::HEAP_START + heap_size - 3;
+        memory.write_bytes(src, &[1, 2, 3, 4, 5]).unwrap();
+
+        let registers = [dst, src, 5, 0, 0];
+        let result = sol_memcpy(registers, &mut memory, &meter(1_000_000), &costs());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_memcpy_oob_src() {
+        let mut memory = make_memory();
+        let heap_size = 64 * 1024u64;
+        let src = Memory::HEAP_START + heap_size - 2;
+        let dst = Memory::HEAP_START;
+
+        let registers = [dst, src, 5, 0, 0];
+        let result = sol_memcpy(registers, &mut memory, &meter(1_000_000), &costs());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_memmove_basic() {
+        let mut memory = make_memory();
+        let src = Memory::HEAP_START;
+        let dst = Memory::HEAP_START + 64;
+        memory.write_bytes(src, &[5, 4, 3, 2, 1]).unwrap();
+
+        let registers = [dst, src, 5, 0, 0];
+        sol_memmove(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        assert_eq!(memory.read_bytes(dst, 5).unwrap(), &[5, 4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn test_memmove_overlapping_allowed() {
+        let mut memory = make_memory();
+        let src = Memory::HEAP_START;
+        let dst = Memory::HEAP_START + 4;
+        memory.write_bytes(src, &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+
+        let registers = [dst, src, 8, 0, 0];
+        sol_memmove(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+    }
+
+    #[test]
+    fn test_memmove_compute_exhausted() {
+        let mut memory = make_memory();
+        memory.write_bytes(Memory::HEAP_START, &[1]).unwrap();
+        let registers = [Memory::HEAP_START + 64, Memory::HEAP_START, 1, 0, 0];
+        assert!(matches!(
+            sol_memmove(registers, &mut memory, &meter(9), &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_memset_basic() {
+        let mut memory = make_memory();
+        let dst = Memory::HEAP_START;
+
+        let registers = [dst, 0xAB, 8, 0, 0];
+        sol_memset(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        assert_eq!(memory.read_bytes(dst, 8).unwrap(), &[0xAB; 8]);
+    }
+
+    #[test]
+    fn test_memset_zero_fill() {
+        let mut memory = make_memory();
+        let dst = Memory::HEAP_START;
+        memory.write_bytes(dst, &[0xFF; 4]).unwrap();
+
+        let registers = [dst, 0x00, 4, 0, 0];
+        sol_memset(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+        assert_eq!(memory.read_bytes(dst, 4).unwrap(), &[0u8; 4]);
+    }
+
+    #[test]
+    fn test_memset_compute_exhausted() {
+        let mut memory = make_memory();
+        let registers = [Memory::HEAP_START, 0xFF, 5, 0, 0];
+        assert!(matches!(
+            sol_memset(registers, &mut memory, &meter(9), &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_memcmp_equal() {
+        let mut memory = make_memory();
+        let s1 = Memory::HEAP_START;
+        let s2 = Memory::HEAP_START + 16;
+        let result_ptr = Memory::HEAP_START + 32;
+        memory.write_bytes(s1, &[1, 2, 3, 4, 5]).unwrap();
+        memory.write_bytes(s2, &[1, 2, 3, 4, 5]).unwrap();
+
+        let registers = [s1, s2, 5, result_ptr, 0];
+        sol_memcmp(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let cmp = memory.read_u32(result_ptr).unwrap() as i32;
+        assert_eq!(cmp, 0);
+    }
+
+    #[test]
+    fn test_memcmp_less_than() {
+        let mut memory = make_memory();
+        let s1 = Memory::HEAP_START;
+        let s2 = Memory::HEAP_START + 16;
+        let result_ptr = Memory::HEAP_START + 32;
+        // s1[2]=3, s2[2]=4 → 3 - 4 = -1
+        memory.write_bytes(s1, &[1, 2, 3]).unwrap();
+        memory.write_bytes(s2, &[1, 2, 4]).unwrap();
+
+        let registers = [s1, s2, 3, result_ptr, 0];
+        sol_memcmp(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let cmp = memory.read_u32(result_ptr).unwrap() as i32;
+        assert!(cmp < 0);
+    }
+
+    #[test]
+    fn test_memcmp_greater_than() {
+        let mut memory = make_memory();
+        let s1 = Memory::HEAP_START;
+        let s2 = Memory::HEAP_START + 16;
+        let result_ptr = Memory::HEAP_START + 32;
+        memory.write_bytes(s1, &[1, 2, 5]).unwrap();
+        memory.write_bytes(s2, &[1, 2, 4]).unwrap();
+
+        let registers = [s1, s2, 3, result_ptr, 0];
+        sol_memcmp(registers, &mut memory, &meter(1_000_000), &costs()).unwrap();
+
+        let cmp = memory.read_u32(result_ptr).unwrap() as i32;
+        assert!(cmp > 0);
+    }
+
+    #[test]
+    fn test_memcmp_compute_exhausted() {
+        let mut memory = make_memory();
+        let s1 = Memory::HEAP_START;
+        let s2 = Memory::HEAP_START + 16;
+        let result_ptr = Memory::HEAP_START + 32;
+        let registers = [s1, s2, 5, result_ptr, 0];
+        assert!(matches!(
+            sol_memcmp(registers, &mut memory, &meter(9), &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+}

--- a/crates/runtime/src/syscalls/mod.rs
+++ b/crates/runtime/src/syscalls/mod.rs
@@ -313,9 +313,7 @@ mod tests {
         let mut h = handler();
         let mut memory = Memory::new(vec![], vec![], 4096, 4096);
         let compute = ComputeMeter::new(LIMIT);
-        let err = h
-            .handle("abort", [0; 5], &mut memory, compute)
-            .unwrap_err();
+        let err = h.handle("abort", [0; 5], &mut memory, compute).unwrap_err();
         assert!(matches!(err, SbpfVmError::Abort));
     }
 

--- a/crates/runtime/src/syscalls/mod.rs
+++ b/crates/runtime/src/syscalls/mod.rs
@@ -205,11 +205,31 @@ impl SyscallHandler for RuntimeSyscallHandler {
 #[cfg(test)]
 mod tests {
     use {
+        self::test_helpers::{make_memory, meter},
         super::*,
         crate::cpi::request::{CallerAccountInfo, CpiAccountMeta},
         sbpf_vm::errors::SbpfVmError,
         std::{cell::RefCell, rc::Rc},
     };
+
+    pub(crate) mod test_helpers {
+        use {
+            crate::config::ExecutionCost,
+            sbpf_vm::{compute::ComputeMeter, memory::Memory},
+        };
+
+        pub fn make_memory() -> Memory {
+            Memory::new(vec![], vec![], 4096, 64 * 1024)
+        }
+
+        pub fn costs() -> ExecutionCost {
+            ExecutionCost::default()
+        }
+
+        pub fn meter(limit: u64) -> ComputeMeter {
+            ComputeMeter::new(limit)
+        }
+    }
 
     const LIMIT: u64 = 1_000_000;
 
@@ -260,10 +280,10 @@ mod tests {
             caller_accounts: vec![caller(a, 1000), caller(b, 500)],
             signers: Vec::new(),
         };
-        let compute = ComputeMeter::new(LIMIT);
+        let compute = meter(LIMIT);
         consume_cpi_compute_units(&request, &compute, &costs).unwrap();
 
-        let expected = costs.invoke_units + 3 + 0 + 0 + 4 + 2;
+        let expected = costs.invoke_units + 3 + 4 + 2;
         assert_eq!(compute.get_consumed(), expected);
     }
 
@@ -277,7 +297,7 @@ mod tests {
             caller_accounts: Vec::new(),
             signers: Vec::new(),
         };
-        let compute = ComputeMeter::new(LIMIT);
+        let compute = meter(LIMIT);
         consume_cpi_compute_units(&request, &compute, &costs).unwrap();
         assert_eq!(compute.get_consumed(), costs.invoke_units);
     }
@@ -299,8 +319,8 @@ mod tests {
     #[test]
     fn handle_unknown_syscall_charges_base_and_returns_zero() {
         let mut h = handler();
-        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
-        let compute = ComputeMeter::new(LIMIT);
+        let mut memory = make_memory();
+        let compute = meter(LIMIT);
         let out = h
             .handle("sol_does_not_exist", [0; 5], &mut memory, compute.clone())
             .unwrap();
@@ -311,8 +331,8 @@ mod tests {
     #[test]
     fn handle_abort_returns_abort_error() {
         let mut h = handler();
-        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
-        let compute = ComputeMeter::new(LIMIT);
+        let mut memory = make_memory();
+        let compute = meter(LIMIT);
         let err = h.handle("abort", [0; 5], &mut memory, compute).unwrap_err();
         assert!(matches!(err, SbpfVmError::Abort));
     }
@@ -320,8 +340,8 @@ mod tests {
     #[test]
     fn handle_log_64_writes_log() {
         let mut h = handler();
-        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
-        let compute = ComputeMeter::new(LIMIT);
+        let mut memory = make_memory();
+        let compute = meter(LIMIT);
         h.handle("sol_log_64_", [1, 2, 3, 4, 5], &mut memory, compute)
             .unwrap();
         assert!(!h.log_collector.borrow().is_empty());
@@ -330,8 +350,8 @@ mod tests {
     #[test]
     fn handle_remaining_compute_units_reports_remaining() {
         let mut h = handler();
-        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
-        let compute = ComputeMeter::new(LIMIT);
+        let mut memory = make_memory();
+        let compute = meter(LIMIT);
         let out = h
             .handle(
                 "sol_remaining_compute_units",

--- a/crates/runtime/src/syscalls/mod.rs
+++ b/crates/runtime/src/syscalls/mod.rs
@@ -201,3 +201,148 @@ impl SyscallHandler for RuntimeSyscallHandler {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::cpi::request::{CallerAccountInfo, CpiAccountMeta},
+        sbpf_vm::errors::SbpfVmError,
+        std::{cell::RefCell, rc::Rc},
+    };
+
+    const LIMIT: u64 = 1_000_000;
+
+    fn addr(seed: u8) -> Address {
+        Address::new_from_array([seed; 32])
+    }
+
+    fn meta(pubkey: Address) -> CpiAccountMeta {
+        CpiAccountMeta {
+            pubkey,
+            is_signer: false,
+            is_writable: true,
+        }
+    }
+
+    fn caller(pubkey: Address, data_len: u64) -> CallerAccountInfo {
+        CallerAccountInfo {
+            pubkey,
+            lamports_addr: 0,
+            data_addr: 0,
+            data_len,
+            owner_addr: 0,
+            vm_data_len_addr: 0,
+            is_writable: true,
+        }
+    }
+
+    fn handler() -> RuntimeSyscallHandler {
+        RuntimeSyscallHandler::new(
+            ExecutionCost::default(),
+            addr(7),
+            SysvarContext::default(),
+            Rc::new(RefCell::new(Vec::new())),
+        )
+    }
+
+    #[test]
+    fn consume_cpi_compute_units_dedups_and_charges_data() {
+        let costs = ExecutionCost::default();
+        let a = addr(1);
+        let b = addr(2);
+        let c = addr(3);
+        // `a` is duplicated (should be charged once); `c` has no caller entry.
+        let request = CpiRequest {
+            program_id: addr(9),
+            accounts: vec![meta(a), meta(b), meta(c), meta(a)],
+            data: vec![0u8; 800],
+            caller_accounts: vec![caller(a, 1000), caller(b, 500)],
+            signers: Vec::new(),
+        };
+        let compute = ComputeMeter::new(LIMIT);
+        consume_cpi_compute_units(&request, &compute, &costs).unwrap();
+
+        let expected = costs.invoke_units + 3 + 0 + 0 + 4 + 2;
+        assert_eq!(compute.get_consumed(), expected);
+    }
+
+    #[test]
+    fn consume_cpi_compute_units_no_caller_accounts() {
+        let costs = ExecutionCost::default();
+        let request = CpiRequest {
+            program_id: addr(9),
+            accounts: vec![meta(addr(1)), meta(addr(2))],
+            data: Vec::new(),
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+        let compute = ComputeMeter::new(LIMIT);
+        consume_cpi_compute_units(&request, &compute, &costs).unwrap();
+        assert_eq!(compute.get_consumed(), costs.invoke_units);
+    }
+
+    #[test]
+    fn consume_cpi_compute_units_out_of_budget() {
+        let costs = ExecutionCost::default();
+        let request = CpiRequest {
+            program_id: addr(9),
+            accounts: vec![meta(addr(1))],
+            data: Vec::new(),
+            caller_accounts: Vec::new(),
+            signers: Vec::new(),
+        };
+        let compute = ComputeMeter::new(10); // less than invoke_units
+        assert!(consume_cpi_compute_units(&request, &compute, &costs).is_err());
+    }
+
+    #[test]
+    fn handle_unknown_syscall_charges_base_and_returns_zero() {
+        let mut h = handler();
+        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
+        let compute = ComputeMeter::new(LIMIT);
+        let out = h
+            .handle("sol_does_not_exist", [0; 5], &mut memory, compute.clone())
+            .unwrap();
+        assert_eq!(out, 0);
+        assert_eq!(compute.get_consumed(), h.costs.syscall_base_cost);
+    }
+
+    #[test]
+    fn handle_abort_returns_abort_error() {
+        let mut h = handler();
+        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
+        let compute = ComputeMeter::new(LIMIT);
+        let err = h
+            .handle("abort", [0; 5], &mut memory, compute)
+            .unwrap_err();
+        assert!(matches!(err, SbpfVmError::Abort));
+    }
+
+    #[test]
+    fn handle_log_64_writes_log() {
+        let mut h = handler();
+        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
+        let compute = ComputeMeter::new(LIMIT);
+        h.handle("sol_log_64_", [1, 2, 3, 4, 5], &mut memory, compute)
+            .unwrap();
+        assert!(!h.log_collector.borrow().is_empty());
+    }
+
+    #[test]
+    fn handle_remaining_compute_units_reports_remaining() {
+        let mut h = handler();
+        let mut memory = Memory::new(vec![], vec![], 4096, 4096);
+        let compute = ComputeMeter::new(LIMIT);
+        let out = h
+            .handle(
+                "sol_remaining_compute_units",
+                [0; 5],
+                &mut memory,
+                compute.clone(),
+            )
+            .unwrap();
+        // Reports the remaining budget after charging its own cost.
+        assert_eq!(out, compute.get_remaining());
+    }
+}

--- a/crates/runtime/src/syscalls/pda.rs
+++ b/crates/runtime/src/syscalls/pda.rs
@@ -104,21 +104,10 @@ pub fn sol_try_find_program_address(
 mod tests {
     use {
         super::*,
-        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        crate::syscalls::tests::test_helpers::{costs, make_memory, meter},
+        sbpf_vm::{errors::SbpfVmError, memory::Memory},
         solana_address::Address,
     };
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 64 * 1024)
-    }
-
-    fn costs() -> ExecutionCost {
-        ExecutionCost::default()
-    }
-
-    fn meter(limit: u64) -> ComputeMeter {
-        ComputeMeter::new(limit)
-    }
 
     fn setup_seeds(
         memory: &mut Memory,

--- a/crates/runtime/src/syscalls/pda.rs
+++ b/crates/runtime/src/syscalls/pda.rs
@@ -99,3 +99,190 @@ pub fn sol_try_find_program_address(
     }
     Ok(1)
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        solana_address::Address,
+    };
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 64 * 1024)
+    }
+
+    fn costs() -> ExecutionCost {
+        ExecutionCost::default()
+    }
+
+    fn meter(limit: u64) -> ComputeMeter {
+        ComputeMeter::new(limit)
+    }
+
+    fn setup_seeds(
+        memory: &mut Memory,
+        seeds: &[&[u8]],
+        program_id: &Address,
+    ) -> (u64, u64, u64, u64) {
+        // Write each seed's bytes starting at offset 0, spaced 64 bytes apart
+        let mut seed_data_addrs = Vec::new();
+        for (i, seed) in seeds.iter().enumerate() {
+            let addr = Memory::HEAP_START + (i as u64 * 64);
+            memory.write_bytes(addr, seed).unwrap();
+            seed_data_addrs.push((addr, seed.len() as u64));
+        }
+
+        // Write the slice-descriptor array after all seed data
+        let seeds_addr = Memory::HEAP_START + 1024;
+        for (i, (ptr, len)) in seed_data_addrs.iter().enumerate() {
+            let desc = seeds_addr + (i as u64 * 16);
+            memory.write_u64(desc, *ptr).unwrap();
+            memory.write_u64(desc + 8, *len).unwrap();
+        }
+
+        let program_id_addr = Memory::HEAP_START + 2048;
+        memory
+            .write_bytes(program_id_addr, program_id.as_ref())
+            .unwrap();
+
+        let address_out_addr = Memory::HEAP_START + 2096;
+
+        (
+            seeds_addr,
+            seeds.len() as u64,
+            program_id_addr,
+            address_out_addr,
+        )
+    }
+
+    #[test]
+    fn test_create_program_address_valid_pda() {
+        let mut memory = make_memory();
+        let program_id = Address::from([2u8; 32]);
+
+        // find_program_address gives us seeds+bump that produce a valid PDA
+        let (expected_addr, bump) = Address::find_program_address(&[b"test"], &program_id);
+        let bump_bytes = [bump];
+
+        let (seeds_addr, seeds_len, program_id_addr, address_out_addr) =
+            setup_seeds(&mut memory, &[b"test", &bump_bytes], &program_id);
+
+        let registers = [seeds_addr, seeds_len, program_id_addr, address_out_addr, 0];
+        let ret = sol_create_program_address(registers, &mut memory, &meter(1_000_000), &costs())
+            .unwrap();
+
+        assert_eq!(ret, 0, "should return 0 for a valid PDA");
+        let written_addr: [u8; 32] = memory
+            .read_bytes(address_out_addr, 32)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert_eq!(Address::from(written_addr), expected_addr);
+    }
+
+    #[test]
+    fn test_create_program_address_too_many_seeds() {
+        let mut memory = make_memory();
+        let program_id = Address::from([1u8; 32]);
+        // 17 seeds exceeds MAX_SEEDS=16
+        let seeds: Vec<&[u8]> = (0..17).map(|_| b"s".as_ref()).collect();
+        let (seeds_addr, seeds_len, program_id_addr, address_out_addr) =
+            setup_seeds(&mut memory, &seeds, &program_id);
+
+        let registers = [seeds_addr, seeds_len, program_id_addr, address_out_addr, 0];
+        assert!(matches!(
+            sol_create_program_address(registers, &mut memory, &meter(1_000_000), &costs()),
+            Err(SbpfVmError::MaxSeedLengthExceeded)
+        ));
+    }
+
+    #[test]
+    fn test_create_program_address_seed_too_long() {
+        let mut memory = make_memory();
+        let program_id = Address::from([1u8; 32]);
+        // 33-byte seed exceeds MAX_SEED_LEN=32
+        let long_seed = [0u8; 33];
+        let (seeds_addr, seeds_len, program_id_addr, address_out_addr) =
+            setup_seeds(&mut memory, &[&long_seed], &program_id);
+
+        let registers = [seeds_addr, seeds_len, program_id_addr, address_out_addr, 0];
+        assert!(matches!(
+            sol_create_program_address(registers, &mut memory, &meter(1_000_000), &costs()),
+            Err(SbpfVmError::MaxSeedLengthExceeded)
+        ));
+    }
+
+    #[test]
+    fn test_create_program_address_compute_exhausted() {
+        let mut memory = make_memory();
+        let program_id = Address::from([1u8; 32]);
+        let (seeds_addr, seeds_len, program_id_addr, address_out_addr) =
+            setup_seeds(&mut memory, &[b"seed"], &program_id);
+
+        let registers = [seeds_addr, seeds_len, program_id_addr, address_out_addr, 0];
+        // create_program_address_units = 1500; budget=1499 fails
+        assert!(matches!(
+            sol_create_program_address(registers, &mut memory, &meter(1499), &costs()),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_try_find_program_address_matches_library() {
+        let mut memory = make_memory();
+        let program_id = Address::from([3u8; 32]);
+
+        let (seeds_addr, seeds_len, program_id_addr, address_out_addr) =
+            setup_seeds(&mut memory, &[b"find-me"], &program_id);
+
+        let bump_out_addr = Memory::HEAP_START + 2200;
+
+        let registers = [
+            seeds_addr,
+            seeds_len,
+            program_id_addr,
+            address_out_addr,
+            bump_out_addr,
+        ];
+        let ret = sol_try_find_program_address(registers, &mut memory, &meter(1_000_000), &costs())
+            .unwrap();
+
+        assert_eq!(ret, 0, "should find a valid PDA");
+
+        let written_bump = memory.read_u8(bump_out_addr).unwrap();
+        let written_addr: [u8; 32] = memory
+            .read_bytes(address_out_addr, 32)
+            .unwrap()
+            .try_into()
+            .unwrap();
+
+        let (expected_addr, expected_bump) =
+            Address::find_program_address(&[b"find-me"], &program_id);
+
+        assert_eq!(written_bump, expected_bump);
+        assert_eq!(Address::from(written_addr), expected_addr);
+    }
+
+    #[test]
+    fn test_try_find_program_address_too_many_seeds() {
+        let mut memory = make_memory();
+        let program_id = Address::from([1u8; 32]);
+        let seeds: Vec<&[u8]> = (0..17).map(|_| b"x".as_ref()).collect();
+        let (seeds_addr, seeds_len, program_id_addr, address_out_addr) =
+            setup_seeds(&mut memory, &seeds, &program_id);
+
+        let bump_out_addr = Memory::HEAP_START + 2200;
+        let registers = [
+            seeds_addr,
+            seeds_len,
+            program_id_addr,
+            address_out_addr,
+            bump_out_addr,
+        ];
+        assert!(matches!(
+            sol_try_find_program_address(registers, &mut memory, &meter(1_000_000), &costs()),
+            Err(SbpfVmError::MaxSeedLengthExceeded)
+        ));
+    }
+}

--- a/crates/runtime/src/syscalls/return_data.rs
+++ b/crates/runtime/src/syscalls/return_data.rs
@@ -76,22 +76,10 @@ pub fn sol_get_return_data(
 mod tests {
     use {
         super::*,
-        crate::config::ExecutionCost,
-        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        crate::syscalls::tests::test_helpers::{costs, make_memory, meter},
+        sbpf_vm::{errors::SbpfVmError, memory::Memory},
         solana_address::Address,
     };
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 4096)
-    }
-
-    fn costs() -> ExecutionCost {
-        ExecutionCost::default()
-    }
-
-    fn meter(limit: u64) -> ComputeMeter {
-        ComputeMeter::new(limit)
-    }
 
     fn test_program_id() -> Address {
         Address::from([7u8; 32])

--- a/crates/runtime/src/syscalls/return_data.rs
+++ b/crates/runtime/src/syscalls/return_data.rs
@@ -71,3 +71,178 @@ pub fn sol_get_return_data(
 
     Ok(data.len() as u64)
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::config::ExecutionCost,
+        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        solana_address::Address,
+    };
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 4096)
+    }
+
+    fn costs() -> ExecutionCost {
+        ExecutionCost::default()
+    }
+
+    fn meter(limit: u64) -> ComputeMeter {
+        ComputeMeter::new(limit)
+    }
+
+    fn test_program_id() -> Address {
+        Address::from([7u8; 32])
+    }
+
+    #[test]
+    fn test_set_return_data_basic() {
+        let mut memory = make_memory();
+        let data = b"result";
+        memory.write_bytes(Memory::HEAP_START, data).unwrap();
+
+        let program_id = test_program_id();
+        let registers = [Memory::HEAP_START, data.len() as u64, 0, 0, 0];
+        let (ret, rd) =
+            sol_set_return_data(registers, &memory, &meter(1_000_000), &costs(), &program_id)
+                .unwrap();
+
+        assert_eq!(ret, 0);
+        let (stored_id, stored_data) = rd.unwrap();
+        assert_eq!(stored_id, program_id);
+        assert_eq!(stored_data, data);
+    }
+
+    #[test]
+    fn test_set_return_data_empty() {
+        let memory = make_memory();
+        let program_id = test_program_id();
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        let (ret, rd) =
+            sol_set_return_data(registers, &memory, &meter(1_000_000), &costs(), &program_id)
+                .unwrap();
+
+        assert_eq!(ret, 0);
+        let (_, stored_data) = rd.unwrap();
+        assert!(stored_data.is_empty());
+    }
+
+    #[test]
+    fn test_set_return_data_too_large() {
+        let memory = make_memory();
+        let program_id = test_program_id();
+        // MAX_RETURN_DATA = 1024; pass 1025
+        let registers = [Memory::HEAP_START, 1025, 0, 0, 0];
+        let result =
+            sol_set_return_data(registers, &memory, &meter(1_000_000), &costs(), &program_id);
+        assert!(matches!(result, Err(SbpfVmError::SyscallError(_))));
+    }
+
+    #[test]
+    fn test_set_return_data_compute_exhausted() {
+        let memory = make_memory();
+        let program_id = test_program_id();
+        // cost = 0/250 + syscall_base_cost=100; budget=99 fails
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        assert!(matches!(
+            sol_set_return_data(registers, &memory, &meter(99), &costs(), &program_id),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_get_return_data_none() {
+        let mut memory = make_memory();
+        let registers = [Memory::HEAP_START, 32, Memory::HEAP_START + 64, 0, 0];
+        let ret = sol_get_return_data(registers, &mut memory, &meter(1_000_000), &costs(), &None)
+            .unwrap();
+        assert_eq!(ret, 0);
+    }
+
+    #[test]
+    fn test_get_return_data_full() {
+        let mut memory = make_memory();
+        let program_id = test_program_id();
+        let data = vec![1u8, 2, 3, 4, 5];
+        let return_data: ReturnData = Some((program_id, data.clone()));
+
+        let buf_addr = Memory::HEAP_START;
+        let pid_addr = Memory::HEAP_START + 64;
+        let registers = [buf_addr, data.len() as u64, pid_addr, 0, 0];
+        let ret = sol_get_return_data(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &return_data,
+        )
+        .unwrap();
+
+        assert_eq!(ret, data.len() as u64);
+        assert_eq!(
+            memory.read_bytes(buf_addr, data.len()).unwrap(),
+            data.as_slice()
+        );
+        assert_eq!(
+            memory.read_bytes(pid_addr, 32).unwrap(),
+            program_id.as_ref()
+        );
+    }
+
+    #[test]
+    fn test_get_return_data_truncated_buf() {
+        let mut memory = make_memory();
+        let program_id = test_program_id();
+        let data = vec![10u8, 20, 30, 40, 50];
+        let return_data: ReturnData = Some((program_id, data.clone()));
+
+        let buf_addr = Memory::HEAP_START;
+        let pid_addr = Memory::HEAP_START + 64;
+        // buf_len=3; should write only first 3 bytes but return full 5
+        let registers = [buf_addr, 3, pid_addr, 0, 0];
+        let ret = sol_get_return_data(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &return_data,
+        )
+        .unwrap();
+
+        assert_eq!(ret, 5, "returns full data length even when buf is smaller");
+        assert_eq!(memory.read_bytes(buf_addr, 3).unwrap(), &[10, 20, 30]);
+    }
+
+    #[test]
+    fn test_get_return_data_zero_buf_len() {
+        let mut memory = make_memory();
+        let program_id = test_program_id();
+        let data = vec![1u8, 2, 3];
+        let return_data: ReturnData = Some((program_id, data.clone()));
+
+        // buf_len=0 → length=0 → no write, but returns data.len()
+        let registers = [Memory::HEAP_START, 0, Memory::HEAP_START + 64, 0, 0];
+        let ret = sol_get_return_data(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &return_data,
+        )
+        .unwrap();
+        assert_eq!(ret, 3);
+    }
+
+    #[test]
+    fn test_get_return_data_compute_exhausted() {
+        let mut memory = make_memory();
+        let registers = [Memory::HEAP_START, 32, Memory::HEAP_START + 64, 0, 0];
+        // syscall_base_cost=100; budget=99 fails
+        assert!(matches!(
+            sol_get_return_data(registers, &mut memory, &meter(99), &costs(), &None),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+}

--- a/crates/runtime/src/syscalls/sysvar.rs
+++ b/crates/runtime/src/syscalls/sysvar.rs
@@ -77,3 +77,129 @@ pub fn sol_get_last_restart_slot_sysvar(
     write_sysvar_bytes(memory, registers[0], &sysvars.last_restart_slot)?;
     Ok(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::config::{ExecutionCost, SysvarContext},
+        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+    };
+
+    fn make_memory() -> Memory {
+        Memory::new(vec![], vec![], 4096, 4096)
+    }
+
+    fn costs() -> ExecutionCost {
+        ExecutionCost::default()
+    }
+
+    fn meter(limit: u64) -> ComputeMeter {
+        ComputeMeter::new(limit)
+    }
+
+    fn raw_bytes<T>(val: &T) -> Vec<u8> {
+        unsafe { std::slice::from_raw_parts(val as *const T as *const u8, size_of::<T>()).to_vec() }
+    }
+
+    #[test]
+    fn test_sol_get_clock_sysvar() {
+        let mut memory = make_memory();
+        let mut sysvars = SysvarContext::default();
+        sysvars.clock.slot = 99_999;
+        sysvars.clock.unix_timestamp = 1_700_000_000;
+
+        let addr = Memory::HEAP_START;
+        let registers = [addr, 0, 0, 0, 0];
+        sol_get_clock_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+
+        let written = memory.read_bytes(addr, size_of::<Clock>()).unwrap();
+        assert_eq!(written, raw_bytes(&sysvars.clock).as_slice());
+    }
+
+    #[test]
+    fn test_sol_get_clock_sysvar_compute_exhausted() {
+        let mut memory = make_memory();
+        let sysvars = SysvarContext::default();
+        let cost = costs().sysvar_base_cost + size_of::<Clock>() as u64;
+        let registers = [Memory::HEAP_START, 0, 0, 0, 0];
+        assert!(matches!(
+            sol_get_clock_sysvar(registers, &mut memory, &meter(cost - 1), &costs(), &sysvars),
+            Err(SbpfVmError::ComputeBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sol_get_rent_sysvar() {
+        let mut memory = make_memory();
+        let sysvars = SysvarContext {
+            rent: Rent::with_lamports_per_byte(3_480),
+            ..Default::default()
+        };
+
+        let addr = Memory::HEAP_START;
+        let registers = [addr, 0, 0, 0, 0];
+        sol_get_rent_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+
+        let written = memory.read_bytes(addr, size_of::<Rent>()).unwrap();
+        assert_eq!(written, raw_bytes(&sysvars.rent).as_slice());
+    }
+
+    #[test]
+    fn test_sol_get_epoch_schedule_sysvar() {
+        let mut memory = make_memory();
+        let mut sysvars = SysvarContext::default();
+        sysvars.epoch_schedule.slots_per_epoch = 432_000;
+
+        let addr = Memory::HEAP_START;
+        let registers = [addr, 0, 0, 0, 0];
+        sol_get_epoch_schedule_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+
+        let written = memory.read_bytes(addr, size_of::<EpochSchedule>()).unwrap();
+        assert_eq!(written, raw_bytes(&sysvars.epoch_schedule).as_slice());
+    }
+
+    #[test]
+    fn test_sol_get_last_restart_slot_sysvar() {
+        let mut memory = make_memory();
+        let mut sysvars = SysvarContext::default();
+        sysvars.last_restart_slot.last_restart_slot = 12_345_678;
+
+        let addr = Memory::HEAP_START;
+        let registers = [addr, 0, 0, 0, 0];
+        sol_get_last_restart_slot_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+
+        let written = memory
+            .read_bytes(addr, size_of::<LastRestartSlot>())
+            .unwrap();
+        assert_eq!(written, raw_bytes(&sysvars.last_restart_slot).as_slice());
+    }
+}

--- a/crates/runtime/src/syscalls/sysvar.rs
+++ b/crates/runtime/src/syscalls/sysvar.rs
@@ -82,21 +82,12 @@ pub fn sol_get_last_restart_slot_sysvar(
 mod tests {
     use {
         super::*,
-        crate::config::{ExecutionCost, SysvarContext},
-        sbpf_vm::{compute::ComputeMeter, errors::SbpfVmError, memory::Memory},
+        crate::{
+            config::SysvarContext,
+            syscalls::tests::test_helpers::{costs, make_memory, meter},
+        },
+        sbpf_vm::{errors::SbpfVmError, memory::Memory},
     };
-
-    fn make_memory() -> Memory {
-        Memory::new(vec![], vec![], 4096, 4096)
-    }
-
-    fn costs() -> ExecutionCost {
-        ExecutionCost::default()
-    }
-
-    fn meter(limit: u64) -> ComputeMeter {
-        ComputeMeter::new(limit)
-    }
 
     fn raw_bytes<T>(val: &T) -> Vec<u8> {
         unsafe { std::slice::from_raw_parts(val as *const T as *const u8, size_of::<T>()).to_vec() }


### PR DESCRIPTION
this PR adds unit tests to the `sbpf-runtime` crate

<img width="1037" height="748" alt="image" src="https://github.com/user-attachments/assets/2b5dcde1-a73b-40d1-8435-7c987a95ed17" />
