### PR TITLE
feat(disassembler): make DisassemblerError variants carry diagnostics

### DIFF
--- a/crates/disassembler/src/elf_header.rs
+++ b/crates/disassembler/src/elf_header.rs
@@ -72,18 +72,80 @@ impl ELFHeader {
         let e_shnum = elf_header.e_shnum.get(endian);
         let e_shstrndx = elf_header.e_shstrndx.get(endian);
 
-        // Validate ELF header fields.
-        if e_ident.magic.ne(&EI_MAGIC)
-            || e_ident.class.ne(&EI_CLASS)
-            || e_ident.data.ne(&EI_DATA)
-            || e_ident.version.ne(&EI_VERSION)
-            || !matches!(e_ident.os_abi, EI_OSABI | EI_OSABI_LINUX)
-            || e_ident.abi_version.ne(&EI_ABIVERSION)
-            || e_ident.padding.ne(&EI_PAD)
-            || (e_machine.ne(&E_MACHINE) && e_machine.ne(&E_MACHINE_SBPF))
-            || e_version.ne(&E_VERSION)
-        {
-            return Err(DisassemblerError::NonStandardElfHeader);
+        if e_ident.magic != EI_MAGIC {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "magic",
+                expected: vec![u32::from_be_bytes(EI_MAGIC) as u64],
+                found: u32::from_be_bytes(e_ident.magic) as u64,
+            });
+        }
+
+        if e_ident.class != EI_CLASS {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "class",
+                expected: vec![EI_CLASS as u64],
+                found: e_ident.class as u64,
+            });
+        }
+
+        if e_ident.data != EI_DATA {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "data",
+                expected: vec![EI_DATA as u64],
+                found: e_ident.data as u64,
+            });
+        }
+
+        if e_ident.version != EI_VERSION {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "ident version",
+                expected: vec![EI_VERSION as u64],
+                found: e_ident.version as u64,
+            });
+        }
+
+        if !matches!(e_ident.os_abi, EI_OSABI | EI_OSABI_LINUX) {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "os abi",
+                expected: vec![EI_OSABI as u64, EI_OSABI_LINUX as u64],
+                found: e_ident.os_abi as u64,
+            });
+        }
+
+        if e_ident.abi_version != EI_ABIVERSION {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "abi version",
+                expected: vec![EI_ABIVERSION as u64],
+                found: e_ident.abi_version as u64,
+            });
+        }
+
+        if e_ident.padding != EI_PAD {
+            // Pack the 7 padding bytes into a u64 (big-endian, so byte order
+            // is preserved when displayed as hex).
+            let mut found = [0u8; 8];
+            found[1..].copy_from_slice(&e_ident.padding);
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "padding",
+                expected: vec![0],
+                found: u64::from_be_bytes(found),
+            });
+        }
+
+        if e_machine != E_MACHINE && e_machine != E_MACHINE_SBPF {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "machine",
+                expected: vec![E_MACHINE as u64, E_MACHINE_SBPF as u64],
+                found: e_machine as u64,
+            });
+        }
+
+        if e_version != E_VERSION {
+            return Err(DisassemblerError::NonStandardElfHeader {
+                field: "version",
+                expected: vec![E_VERSION as u64],
+                found: e_version as u64,
+            });
         }
 
         Ok(ELFHeader {
@@ -146,6 +208,7 @@ mod tests {
                 E_MACHINE, E_MACHINE_SBPF, E_TYPE, E_VERSION, EI_ABIVERSION, EI_CLASS, EI_DATA,
                 EI_MAGIC, EI_OSABI, EI_PAD, EI_VERSION,
             },
+            errors::DisassemblerError,
             program::Program,
         },
         hex_literal::hex,
@@ -215,21 +278,37 @@ mod tests {
         let invalid_magic = hex!(
             "00454C460201010000000000000000000300F700010000000000000000000000400000000000000000000000000000000000000040003800000000000000000000"
         );
-        let result = Program::from_bytes(&invalid_magic);
-        assert!(result.is_err());
+        let err = Program::from_bytes(&invalid_magic).unwrap_err();
+        assert!(
+            matches!(err, DisassemblerError::InvalidElfFile { .. }),
+            "expected InvalidElfFile, got {err:?}"
+        );
 
         // Invalid class (not 64-bit).
         let invalid_class = hex!(
             "7F454C460101010000000000000000000300F700010000000000000000000000400000000000000000000000000000000000000040003800000000000000000000"
         );
-        let result = Program::from_bytes(&invalid_class);
-        assert!(result.is_err());
+        let err = Program::from_bytes(&invalid_class).unwrap_err();
+        assert!(
+            matches!(err, DisassemblerError::InvalidElfFile { .. }),
+            "expected InvalidElfFile, got {err:?}"
+        );
 
         // Invalid endianness (big endian instead of little).
         let invalid_endian = hex!(
             "7F454C460202010000000000000000000300F700010000000000000000000000400000000000000000000000000000000000000040003800000000000000000000"
         );
-        let result = Program::from_bytes(&invalid_endian);
-        assert!(result.is_err());
+        match Program::from_bytes(&invalid_endian) {
+            Err(DisassemblerError::NonStandardElfHeader {
+                field,
+                expected,
+                found,
+            }) => {
+                assert_eq!(field, "data");
+                assert_eq!(expected, vec![EI_DATA as u64]);
+                assert_eq!(found, 0x02);
+            }
+            other => panic!("expected NonStandardElfHeader for data, got {other:?}"),
+        }
     }
 }

--- a/crates/disassembler/src/errors.rs
+++ b/crates/disassembler/src/errors.rs
@@ -1,91 +1,160 @@
-use {sbpf_common::errors::SBPFError, thiserror::Error};
+use {
+    sbpf_common::errors::SBPFError,
+    std::{ops::Range, string::FromUtf8Error},
+    thiserror::Error,
+};
+
+/// Render the acceptable values for an ELF header field, e.g. `0xf7 or 0x107`.
+fn hex_list(values: &[u64]) -> String {
+    values
+        .iter()
+        .map(|v| format!("{v:#x}"))
+        .collect::<Vec<_>>()
+        .join(" or ")
+}
 
 #[derive(Debug, Error)]
 pub enum DisassemblerError {
-    #[error("Non-standard ELF header")]
-    NonStandardElfHeader,
-    #[error("Invalid Program Type")]
-    InvalidProgramType,
-    #[error("Invalid Section Header Type")]
-    InvalidSectionHeaderType,
-    #[error("Invalid OpCode")]
-    InvalidOpcode,
-    #[error("Invalid Immediate")]
-    InvalidImmediate,
-    #[error("Invalid data length")]
-    InvalidDataLength,
-    #[error("Invalid string")]
-    InvalidString,
-    #[error("Bytecode error: {0}")]
-    BytecodeError(String),
-    #[error("Missing text section")]
-    MissingTextSection,
-    #[error("Invalid offset in .dynstr section")]
-    InvalidDynstrOffset,
-    #[error("Non-UTF8 data in .dynstr section")]
-    InvalidUtf8InDynstr,
+    #[error("Failed to parse ELF file: {source}; first bytes: {first_bytes:02x?}")]
+    InvalidElfFile {
+        first_bytes: Vec<u8>,
+        #[source]
+        source: object::read::Error,
+    },
+    #[error("Non-standard ELF header: {field} is {found:#x}, expected {}", hex_list(.expected))]
+    NonStandardElfHeader {
+        field: &'static str,
+        expected: Vec<u64>,
+        found: u64,
+    },
+    #[error("Invalid Program Type: {0:#x}")]
+    InvalidProgramType(u32),
+    #[error("Invalid Section Header Type: {0:#x}")]
+    InvalidSectionHeaderType(u32),
+    #[error("Invalid Relocation Type: {0:#x}")]
+    InvalidRelocationType(u32),
+    #[error("Failed to read {section} section data: {source}")]
+    SectionDataError {
+        section: &'static str,
+        #[source]
+        source: object::read::Error,
+    },
+    #[error("Invalid data length: {0}")]
+    InvalidDataLength(usize),
+    #[error("Bytecode error at bytes {span:?}: {error}")]
+    BytecodeError { error: String, span: Range<usize> },
+    #[error("Missing text section; sections present: {sections:?}")]
+    MissingTextSection { sections: Vec<String> },
+    #[error("Invalid offset in .dynstr section: offset {offset}, data length {data_len}")]
+    InvalidDynstrOffset { offset: usize, data_len: usize },
+    #[error("Non-UTF8 data in .dynstr section: {0}")]
+    InvalidUtf8InDynstr(FromUtf8Error),
 }
 
 impl From<SBPFError> for DisassemblerError {
     fn from(err: SBPFError) -> Self {
         match err {
-            SBPFError::BytecodeError { error, .. } => DisassemblerError::BytecodeError(error),
+            SBPFError::BytecodeError { error, span, .. } => {
+                DisassemblerError::BytecodeError { error, span }
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, object::read::elf::ElfFile64};
 
     #[test]
     fn test_from_sbpf_error() {
         let sbpf_error = SBPFError::BytecodeError {
             error: "test error".to_string(),
-            span: 0..8,
+            span: 8..16,
             custom_label: None,
         };
         let disasm_error: DisassemblerError = sbpf_error.into();
-        assert!(matches!(disasm_error, DisassemblerError::BytecodeError(_)));
+        assert!(matches!(
+            disasm_error,
+            DisassemblerError::BytecodeError { error, span }
+                if error == "test error" && span == (8..16)
+        ));
     }
 
     #[test]
     fn test_error_display() {
+        let empty: &[u8] = &[];
+        let parse_error = ElfFile64::<object::Endianness>::parse(empty).unwrap_err();
+        let msg = DisassemblerError::InvalidElfFile {
+            first_bytes: vec![0x7f, 0x45],
+            source: parse_error,
+        }
+        .to_string();
+        assert!(msg.starts_with("Failed to parse ELF file: "));
+        assert!(msg.ends_with("; first bytes: [7f, 45]"));
+
         assert_eq!(
-            DisassemblerError::NonStandardElfHeader.to_string(),
-            "Non-standard ELF header"
+            DisassemblerError::NonStandardElfHeader {
+                field: "machine",
+                expected: vec![0xf7, 0x107],
+                found: 0x108,
+            }
+            .to_string(),
+            "Non-standard ELF header: machine is 0x108, expected 0xf7 or 0x107"
         );
         assert_eq!(
-            DisassemblerError::InvalidProgramType.to_string(),
-            "Invalid Program Type"
+            DisassemblerError::InvalidProgramType(0x6474e550).to_string(),
+            "Invalid Program Type: 0x6474e550"
         );
         assert_eq!(
-            DisassemblerError::InvalidSectionHeaderType.to_string(),
-            "Invalid Section Header Type"
+            DisassemblerError::InvalidSectionHeaderType(0x6ffffff6).to_string(),
+            "Invalid Section Header Type: 0x6ffffff6"
         );
         assert_eq!(
-            DisassemblerError::InvalidOpcode.to_string(),
-            "Invalid OpCode"
+            DisassemblerError::InvalidRelocationType(0x2a).to_string(),
+            "Invalid Relocation Type: 0x2a"
+        );
+        let section_error = ElfFile64::<object::Endianness>::parse(empty).unwrap_err();
+        assert!(
+            DisassemblerError::SectionDataError {
+                section: ".rel.dyn",
+                source: section_error,
+            }
+            .to_string()
+            .starts_with("Failed to read .rel.dyn section data: ")
         );
         assert_eq!(
-            DisassemblerError::InvalidImmediate.to_string(),
-            "Invalid Immediate"
+            DisassemblerError::InvalidDataLength(13).to_string(),
+            "Invalid data length: 13"
         );
         assert_eq!(
-            DisassemblerError::InvalidDataLength.to_string(),
-            "Invalid data length"
+            DisassemblerError::BytecodeError {
+                error: "custom".to_string(),
+                span: 8..16,
+            }
+            .to_string(),
+            "Bytecode error at bytes 8..16: custom"
         );
         assert_eq!(
-            DisassemblerError::InvalidString.to_string(),
-            "Invalid string"
+            DisassemblerError::MissingTextSection {
+                sections: vec![".rodata".to_string(), ".shstrtab".to_string()],
+            }
+            .to_string(),
+            "Missing text section; sections present: [\".rodata\", \".shstrtab\"]"
         );
         assert_eq!(
-            DisassemblerError::BytecodeError("custom".to_string()).to_string(),
-            "Bytecode error: custom"
+            DisassemblerError::InvalidDynstrOffset {
+                offset: 128,
+                data_len: 64,
+            }
+            .to_string(),
+            "Invalid offset in .dynstr section: offset 128, data length 64"
         );
-        assert_eq!(
-            DisassemblerError::MissingTextSection.to_string(),
-            "Missing text section"
+
+        let utf8_error = String::from_utf8(vec![0x66, 0xff]).unwrap_err();
+        assert!(
+            DisassemblerError::InvalidUtf8InDynstr(utf8_error)
+                .to_string()
+                .starts_with("Non-UTF8 data in .dynstr section: invalid utf-8")
         );
     }
 }

--- a/crates/disassembler/src/program.rs
+++ b/crates/disassembler/src/program.rs
@@ -10,7 +10,9 @@ use {
     },
     either::Either,
     object::{Endianness, read::elf::ElfFile64},
-    sbpf_common::{inst_param::Number, instruction::Instruction, opcode::Opcode},
+    sbpf_common::{
+        errors::SBPFError, inst_param::Number, instruction::Instruction, opcode::Opcode,
+    },
     serde::{Deserialize, Serialize},
     std::collections::{BTreeSet, HashMap},
 };
@@ -29,9 +31,11 @@ pub struct Program {
 
 impl Program {
     pub fn from_bytes(b: &[u8]) -> Result<Self, DisassemblerError> {
-        let elf_file = ElfFile64::<Endianness>::parse(b).map_err(|e| {
-            eprintln!("ELF parse error: {}", e);
-            DisassemblerError::NonStandardElfHeader
+        let elf_file = ElfFile64::<Endianness>::parse(b).map_err(|source| {
+            DisassemblerError::InvalidElfFile {
+                first_bytes: b.get(..16).unwrap_or(b).to_vec(),
+                source,
+            }
         })?;
 
         // Parse elf header.
@@ -153,7 +157,13 @@ impl Program {
             .section_header_entries
             .iter()
             .find(|e| e.label.eq(".text\0"))
-            .ok_or(DisassemblerError::MissingTextSection)?;
+            .ok_or_else(|| DisassemblerError::MissingTextSection {
+                sections: self
+                    .section_header_entries
+                    .iter()
+                    .map(|e| e.label.trim_end_matches('\0').to_string())
+                    .collect(),
+            })?;
         let text_section_offset = text_section.offset as u64;
 
         // Build syscall map
@@ -161,7 +171,7 @@ impl Program {
 
         let data = &text_section.data;
         if !data.len().is_multiple_of(8) {
-            return Err(DisassemblerError::InvalidDataLength);
+            return Err(DisassemblerError::InvalidDataLength(data.len()));
         }
 
         let is_sbpf_v2 =
@@ -188,10 +198,18 @@ impl Program {
 
             // ugly v2 shit we need to fix goes here:
             let mut ix = if is_sbpf_v2 {
-                Instruction::from_bytes_sbpf_v2(remaining)?
+                Instruction::from_bytes_sbpf_v2(remaining)
             } else {
-                Instruction::from_bytes(remaining)?
-            };
+                Instruction::from_bytes(remaining)
+            }
+            .map_err(|e| match e {
+                // Decode spans are relative to the instruction slice; rebase
+                // them to the instruction's offset within .text.
+                SBPFError::BytecodeError { error, span, .. } => DisassemblerError::BytecodeError {
+                    error,
+                    span: span.start + pos..span.end + pos,
+                },
+            })?;
 
             // Handle syscall relocation
             if ix.opcode == Opcode::Call
@@ -475,7 +493,7 @@ impl Program {
 mod tests {
     use {
         crate::{
-            elf_header::{E_MACHINE_SBPF, EI_OSABI_LINUX, ELFHeader},
+            elf_header::{E_MACHINE, E_MACHINE_SBPF, EI_OSABI_LINUX, ELFHeader},
             program::Program,
             section_header_entry::SectionHeaderEntry,
         },
@@ -491,6 +509,22 @@ mod tests {
         bytes[7] = EI_OSABI_LINUX;
         let program = Program::from_bytes(&bytes).unwrap();
         assert_eq!(program.elf_header.ei_osabi, EI_OSABI_LINUX);
+
+        // Corrupt e_machine (LE u16 at bytes 18..20): the error should carry
+        // the field name, the accepted values and the value found.
+        bytes[18] = 0x00;
+        match Program::from_bytes(&bytes) {
+            Err(crate::errors::DisassemblerError::NonStandardElfHeader {
+                field,
+                expected,
+                found,
+            }) => {
+                assert_eq!(field, "machine");
+                assert_eq!(expected, vec![E_MACHINE as u64, E_MACHINE_SBPF as u64]);
+                assert_eq!(found, 0);
+            }
+            other => panic!("expected NonStandardElfHeader for machine, got {other:?}"),
+        }
     }
 
     #[test]
@@ -531,7 +565,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            crate::errors::DisassemblerError::InvalidDataLength
+            crate::errors::DisassemblerError::InvalidDataLength(3)
         ));
     }
 

--- a/crates/disassembler/src/program_header.rs
+++ b/crates/disassembler/src/program_header.rs
@@ -37,7 +37,7 @@ impl TryFrom<u32> for ProgramType {
             5 => Self::PT_SHLIB,
             6 => Self::PT_PHDR,
             7 => Self::PT_TLS,
-            _ => return Err(DisassemblerError::InvalidProgramType),
+            _ => return Err(DisassemblerError::InvalidProgramType(value)),
         })
     }
 }

--- a/crates/disassembler/src/relocation.rs
+++ b/crates/disassembler/src/relocation.rs
@@ -23,7 +23,7 @@ impl TryFrom<u32> for RelocationType {
             0x01 => Self::R_BPF_64_64,
             0x08 => Self::R_BPF_64_RELATIVE,
             0x0a => Self::R_BPF_64_32,
-            _ => return Err(DisassemblerError::InvalidDataLength),
+            _ => return Err(DisassemblerError::InvalidRelocationType(value)),
         })
     }
 }
@@ -45,9 +45,13 @@ impl Relocation {
             None => return Ok(Vec::new()),
         };
 
-        let rel_dyn_data = rel_dyn_section
-            .data()
-            .map_err(|_| DisassemblerError::InvalidDataLength)?;
+        let rel_dyn_data =
+            rel_dyn_section
+                .data()
+                .map_err(|source| DisassemblerError::SectionDataError {
+                    section: ".rel.dyn",
+                    source,
+                })?;
 
         // Extract .dynsym and .dynstr data for symbol resolution.
         let dynsym_data = elf_file
@@ -63,8 +67,7 @@ impl Relocation {
         for chunk in rel_dyn_data.chunks_exact(16) {
             let offset = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
             let rel_type_val = u32::from_le_bytes(chunk[8..12].try_into().unwrap());
-            let rel_type = RelocationType::try_from(rel_type_val)
-                .map_err(|_| DisassemblerError::InvalidDataLength)?;
+            let rel_type = RelocationType::try_from(rel_type_val)?;
             let symbol_index = u32::from_le_bytes(chunk[12..16].try_into().unwrap());
 
             // Resolve symbol name if this is a syscall relocation
@@ -112,7 +115,7 @@ fn resolve_symbol_name(
     // Calculate offset into .dynsym for this symbol.
     let symbol_entry_offset = symbol_index * DYNSYM_ENTRY_SIZE;
     if symbol_entry_offset + 4 > dynsym_data.len() {
-        return Err(DisassemblerError::InvalidDataLength);
+        return Err(DisassemblerError::InvalidDataLength(dynsym_data.len()));
     }
 
     let dynstr_offset = u32::from_le_bytes(
@@ -121,17 +124,23 @@ fn resolve_symbol_name(
             .unwrap(),
     ) as usize;
     if dynstr_offset >= dynstr_data.len() {
-        return Err(DisassemblerError::InvalidDynstrOffset);
+        return Err(DisassemblerError::InvalidDynstrOffset {
+            offset: dynstr_offset,
+            data_len: dynstr_data.len(),
+        });
     }
 
     // Read symbol name from .dynstr data.
     let end = dynstr_data[dynstr_offset..]
         .iter()
         .position(|&b| b == 0)
-        .ok_or(DisassemblerError::InvalidDynstrOffset)?;
+        .ok_or(DisassemblerError::InvalidDynstrOffset {
+            offset: dynstr_offset,
+            data_len: dynstr_data.len(),
+        })?;
 
     String::from_utf8(dynstr_data[dynstr_offset..dynstr_offset + end].to_vec())
-        .map_err(|_| DisassemblerError::InvalidUtf8InDynstr)
+        .map_err(|e| DisassemblerError::InvalidUtf8InDynstr(e))
 }
 
 #[cfg(test)]
@@ -216,5 +225,26 @@ mod tests {
             Relocation::from_elf_file(&elf_file).expect("Failed to parse relocations");
 
         assert!(relocations.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_relocation_type() {
+        // Locate .rel.dyn in the file and corrupt the rel_type field (bytes
+        // 8..12 of the first 16-byte entry).
+        let elf_file = ElfFile64::<Endianness>::parse(TEST_PROGRAM).expect("Failed to parse ELF");
+        let (rel_dyn_offset, _) = elf_file
+            .section_by_name(".rel.dyn")
+            .expect("Failed to find .rel.dyn section")
+            .file_range()
+            .expect("Failed to get .rel.dyn file range");
+
+        let mut bytes = TEST_PROGRAM.to_vec();
+        bytes[rel_dyn_offset as usize + 8] = 0x05;
+
+        let elf_file = ElfFile64::<Endianness>::parse(bytes.as_slice()).expect("Failed to parse");
+        match Relocation::from_elf_file(&elf_file) {
+            Err(DisassemblerError::InvalidRelocationType(rel_type)) => assert_eq!(rel_type, 0x05),
+            other => panic!("expected InvalidRelocationType, got {other:?}"),
+        }
     }
 }

--- a/crates/disassembler/src/relocation.rs
+++ b/crates/disassembler/src/relocation.rs
@@ -140,7 +140,7 @@ fn resolve_symbol_name(
         })?;
 
     String::from_utf8(dynstr_data[dynstr_offset..dynstr_offset + end].to_vec())
-        .map_err(|e| DisassemblerError::InvalidUtf8InDynstr(e))
+        .map_err(DisassemblerError::InvalidUtf8InDynstr)
 }
 
 #[cfg(test)]

--- a/crates/disassembler/src/section_header.rs
+++ b/crates/disassembler/src/section_header.rs
@@ -54,7 +54,7 @@ impl TryFrom<u32> for SectionHeaderType {
             0x12 => Self::SHT_SYMTAB_SHNDX,
             0x13 => Self::SHT_NUM,
             0x6ffffff6 => Self::SHT_GNU_HASH,
-            _ => return Err(DisassemblerError::InvalidSectionHeaderType),
+            _ => return Err(DisassemblerError::InvalidSectionHeaderType(value)),
         })
     }
 }


### PR DESCRIPTION
## Summary

Previously the `DisassemblerError` enum variants reported what failed but not the values involved. Every variant now carries the data describing the failure

## Changes

- `NonStandardElfHeader` reports field name, accepted values, and value found (hex-formatted); type-code variants carry the offending value

- `BytecodeError` keeps the decode span (previously dropped by `From<SBPFError>`), rebased to the instruction's offset in `.text`

- `InvalidElfFile` includes the `object` parse error and the file's first 16 bytes; `MissingTextSection` lists the sections that were found

- Failures misreported as `InvalidDataLength` now use correct variants: `InvalidRelocationType` and `SectionDataError` 

- Removed never constructed variants: `InvalidOpcode`, `InvalidImmediate`, `InvalidString`

- New tests variants (and refactored old ones) to ensure new behaviour 