### PR TITLE
fix: register separate handlers for endian operations

### DIFF
--- a/crates/common/src/decode.rs
+++ b/crates/common/src/decode.rs
@@ -150,6 +150,29 @@ pub fn decode_binary_immediate(bytes: &[u8]) -> Result<Instruction, SBPFError> {
     })
 }
 
+pub fn decode_endian(bytes: &[u8]) -> Result<Instruction, SBPFError> {
+    assert!(bytes.len() >= 8);
+    let (opcode, dst, src, off, imm) = parse_bytes(bytes)?;
+    if src != 0 || off != 0 {
+        return Err(SBPFError::BytecodeError {
+            error: format!(
+                "{} instruction has src: {}, off: {} supposed to be zeros",
+                opcode, src, off
+            ),
+            span: 0..8,
+            custom_label: None,
+        });
+    }
+    Ok(Instruction {
+        opcode,
+        dst: Some(Register { n: dst }),
+        src: None,
+        off: None,
+        imm: Some(Either::Right(Number::Int(imm.into()))),
+        span: 0..8,
+    })
+}
+
 pub fn decode_binary_register(bytes: &[u8]) -> Result<Instruction, SBPFError> {
     assert!(bytes.len() >= 8);
     let (opcode, dst, src, off, imm) = parse_bytes(bytes)?;
@@ -599,6 +622,35 @@ mod tests {
         let bytes = vec![0x87, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
 
         let result = decode_unary(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_endian_valid() {
+        // le16 r1
+        let bytes = vec![0xd4, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00];
+
+        let result = decode_endian(&bytes).unwrap();
+        assert_eq!(result.opcode, Opcode::Le);
+        assert_eq!(result.dst.unwrap().n, 1);
+        assert!(result.src.is_none());
+        assert!(result.off.is_none());
+        assert_eq!(result.span, 0..8);
+    }
+
+    #[test]
+    fn test_decode_endian_error_nonzero_src() {
+        let bytes = vec![0xd4, 0x11, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00];
+
+        let result = decode_endian(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_endian_error_nonzero_off() {
+        let bytes = vec![0xdc, 0x01, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00];
+
+        let result = decode_endian(&bytes);
         assert!(result.is_err());
     }
 

--- a/crates/common/src/execute/mod.rs
+++ b/crates/common/src/execute/mod.rs
@@ -15,7 +15,6 @@ use {
     crate::{errors::ExecutionError, instruction::Instruction, opcode::Opcode},
     alu32::{execute_alu32_imm, execute_alu32_reg, execute_neg32},
     alu64::{execute_alu64_imm, execute_alu64_reg, execute_neg64},
-    endian::execute_endian,
     load::{execute_lddw, execute_ldxb, execute_ldxdw, execute_ldxh, execute_ldxw},
     store::{
         execute_stb, execute_stdw, execute_sth, execute_stw, execute_stxb, execute_stxdw,
@@ -24,6 +23,7 @@ use {
 };
 pub use {
     call::{execute_call_immediate, execute_call_register, execute_exit},
+    endian::execute_endian,
     jump::{execute_jump, execute_jump_immediate, execute_jump_register},
 };
 
@@ -130,7 +130,6 @@ pub fn execute_unary(vm: &mut dyn Vm, inst: &Instruction) -> ExecutionResult<()>
     match inst.opcode {
         Opcode::Neg64 => execute_neg64(vm, inst),
         Opcode::Neg32 => execute_neg32(vm, inst),
-        Opcode::Le | Opcode::Be => execute_endian(vm, inst),
         _ => Err(ExecutionError::InvalidInstruction),
     }
 }

--- a/crates/common/src/inst_handler.rs
+++ b/crates/common/src/inst_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     decode::{
         decode_binary_immediate, decode_binary_register, decode_call_immediate,
-        decode_call_register, decode_exit, decode_jump, decode_jump_immediate,
+        decode_call_register, decode_endian, decode_exit, decode_jump, decode_jump_immediate,
         decode_jump_register, decode_jump32_immediate, decode_jump32_register,
         decode_load_immediate, decode_load_memory, decode_store_immediate, decode_store_register,
         decode_unary,
@@ -9,21 +9,21 @@ use crate::{
     errors::{ExecutionError, SBPFError},
     execute::{
         Vm, execute_binary_immediate, execute_binary_register, execute_call_immediate,
-        execute_call_register, execute_exit, execute_jump, execute_jump_immediate,
+        execute_call_register, execute_endian, execute_exit, execute_jump, execute_jump_immediate,
         execute_jump_register, execute_load_immediate, execute_load_memory,
         execute_store_immediate, execute_store_register, execute_unary,
     },
     instruction::Instruction,
     opcode::{
-        BIN_IMM_OPS, BIN_REG_OPS, CALL_IMM_OPS, CALL_REG_OPS, EXIT_OPS, JUMP_IMM_OPS, JUMP_OPS,
-        JUMP_REG_OPS, JUMP32_IMM_OPS, JUMP32_REG_OPS, LOAD_IMM_OPS, LOAD_MEMORY_OPS, Opcode,
-        OperationType, STORE_IMM_OPS, STORE_REG_OPS, UNARY_OPS,
+        BIN_IMM_OPS, BIN_REG_OPS, CALL_IMM_OPS, CALL_REG_OPS, ENDIAN_OPS, EXIT_OPS, JUMP_IMM_OPS,
+        JUMP_OPS, JUMP_REG_OPS, JUMP32_IMM_OPS, JUMP32_REG_OPS, LOAD_IMM_OPS, LOAD_MEMORY_OPS,
+        Opcode, OperationType, STORE_IMM_OPS, STORE_REG_OPS, UNARY_OPS,
     },
     validate::{
         validate_binary_immediate, validate_binary_register, validate_call_immediate,
-        validate_call_register, validate_exit, validate_jump, validate_jump_immediate,
-        validate_jump_register, validate_load_immediate, validate_load_memory,
-        validate_store_immediate, validate_store_register, validate_unary,
+        validate_call_register, validate_endian, validate_exit, validate_jump,
+        validate_jump_immediate, validate_jump_register, validate_load_immediate,
+        validate_load_memory, validate_store_immediate, validate_store_register, validate_unary,
     },
 };
 
@@ -111,6 +111,13 @@ pub static OPCODE_TO_HANDLER: Lazy<HashMap<Opcode, InstructionHandler>> = Lazy::
         validate_unary,
         execute_unary,
     );
+    register_group(
+        &mut map,
+        ENDIAN_OPS,
+        decode_endian,
+        validate_endian,
+        execute_endian,
+    );
     register_group(&mut map, JUMP_OPS, decode_jump, validate_jump, execute_jump);
     register_group(
         &mut map,
@@ -181,6 +188,7 @@ pub static OPCODE_TO_TYPE: Lazy<HashMap<Opcode, OperationType>> = Lazy::new(|| {
     register_group(&mut map, BIN_IMM_OPS, OperationType::BinaryImmediate);
     register_group(&mut map, BIN_REG_OPS, OperationType::BinaryRegister);
     register_group(&mut map, UNARY_OPS, OperationType::Unary);
+    register_group(&mut map, ENDIAN_OPS, OperationType::Endian);
     register_group(&mut map, JUMP_OPS, OperationType::Jump);
     register_group(&mut map, JUMP_IMM_OPS, OperationType::JumpImmediate);
     register_group(&mut map, JUMP_REG_OPS, OperationType::JumpRegister);

--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -270,11 +270,6 @@ impl Instruction {
 
         match op_type {
             OperationType::BinaryImmediate | OperationType::BinaryRegister => {
-                if self.opcode == Opcode::Le || self.opcode == Opcode::Be {
-                    let bits = self.op_imm_bits()?;
-                    let dst = self.dst.as_ref().unwrap().n;
-                    return Ok(format!("r{} = {} r{}", dst, bits, dst));
-                }
                 let op = self
                     .opcode
                     .to_operator()
@@ -291,6 +286,11 @@ impl Instruction {
                     fmt_imm(self.imm.as_ref().unwrap())
                 };
                 Ok(format!("{}{} {} {}", prefix, dst, op, rhs))
+            }
+            OperationType::Endian => {
+                let bits = self.op_imm_bits()?;
+                let dst = self.dst.as_ref().unwrap().n;
+                Ok(format!("r{} = {} r{}", dst, bits, dst))
             }
             OperationType::Unary => {
                 let prefix = if self.opcode == Opcode::Neg32 {

--- a/crates/common/src/opcode.rs
+++ b/crates/common/src/opcode.rs
@@ -21,6 +21,7 @@ pub enum OperationType {
     BinaryImmediate,
     BinaryRegister,
     Unary,
+    Endian,
     Jump,
     JumpImmediate,
     JumpRegister,
@@ -72,8 +73,6 @@ pub const BIN_IMM_OPS: &[Opcode] = &[
     Opcode::Urem32Imm,
     Opcode::Sdiv32Imm,
     Opcode::Srem32Imm,
-    Opcode::Le,
-    Opcode::Be,
     Opcode::Add64Imm,
     Opcode::Sub64Imm,
     Opcode::Mul64Imm,
@@ -94,6 +93,11 @@ pub const BIN_IMM_OPS: &[Opcode] = &[
     Opcode::Shmul64Imm,
     Opcode::Sdiv64Imm,
     Opcode::Srem64Imm,
+];
+
+pub const ENDIAN_OPS: &[Opcode] = &[
+    Opcode::Le, // OperationType::Endian
+    Opcode::Be,
 ];
 
 pub const BIN_REG_OPS: &[Opcode] = &[
@@ -1118,6 +1122,15 @@ mod tests {
     #[test]
     fn test_all_unary_ops() {
         for &op in UNARY_OPS {
+            let byte: u8 = op.into();
+            let roundtrip = Opcode::try_from(byte).unwrap();
+            assert_eq!(roundtrip, op);
+        }
+    }
+
+    #[test]
+    fn test_all_endian_ops() {
+        for &op in ENDIAN_OPS {
             let byte: u8 = op.into();
             let roundtrip = Opcode::try_from(byte).unwrap();
             assert_eq!(roundtrip, op);

--- a/crates/common/src/validate.rs
+++ b/crates/common/src/validate.rs
@@ -1,4 +1,4 @@
-use crate::{errors::SBPFError, instruction::Instruction};
+use crate::{errors::SBPFError, inst_param::Number, instruction::Instruction};
 
 pub fn validate_load_immediate(inst: &Instruction) -> Result<(), SBPFError> {
     match (&inst.dst, &inst.src, &inst.off, &inst.imm) {
@@ -62,6 +62,38 @@ pub fn validate_unary(inst: &Instruction) -> Result<(), SBPFError> {
         _ => Err(SBPFError::BytecodeError {
             error: format!(
                 "{} instruction requires destination register only",
+                inst.opcode
+            ),
+            span: inst.span.clone(),
+            custom_label: None,
+        }),
+    }
+}
+
+pub fn validate_endian(inst: &Instruction) -> Result<(), SBPFError> {
+    match (&inst.dst, &inst.src, &inst.off, &inst.imm) {
+        (Some(_dst), None, None, Some(imm)) => {
+            let valid_bits = matches!(
+                imm,
+                either::Either::Right(Number::Int(bits)) if *bits == 16 || *bits == 32 || *bits == 64
+            );
+
+            if valid_bits {
+                Ok(())
+            } else {
+                Err(SBPFError::BytecodeError {
+                    error: format!(
+                        "{} instruction requires immediate value of 16, 32, or 64",
+                        inst.opcode
+                    ),
+                    span: inst.span.clone(),
+                    custom_label: None,
+                })
+            }
+        }
+        _ => Err(SBPFError::BytecodeError {
+            error: format!(
+                "{} instruction requires destination register and immediate value",
                 inst.opcode
             ),
             span: inst.span.clone(),
@@ -599,29 +631,52 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_binary_immediate_valid() {
+    fn test_validate_endian_valid() {
         let valid_inst = Instruction {
             opcode: Opcode::Le,
             dst: Some(Register { n: 0 }),
             src: None,
             off: None,
-            imm: Some(Either::Right(Number::Int(16))),
+            imm: Some(Either::Right(Number::Int(32))),
             span: 0..8,
         };
-        assert!(validate_binary_immediate(&valid_inst).is_ok());
+        assert!(validate_endian(&valid_inst).is_ok());
     }
 
     #[test]
-    fn test_validate_binary_immediate_missing_dst() {
+    fn test_validate_endian_invalid_width() {
         let inst = Instruction {
-            opcode: Opcode::Le,
-            dst: None,
+            opcode: Opcode::Be,
+            dst: Some(Register { n: 0 }),
             src: None,
             off: None,
-            imm: Some(Either::Right(Number::Int(16))),
+            imm: Some(Either::Right(Number::Int(8))),
             span: 0..8,
         };
-        let result = validate_binary_immediate(&inst);
+        let result = validate_endian(&inst);
+        assert!(result.is_err());
+        if let Err(SBPFError::BytecodeError { error, .. }) = result {
+            assert_eq!(
+                error,
+                format!(
+                    "{} instruction requires immediate value of 16, 32, or 64",
+                    Opcode::Be
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_endian_missing_imm() {
+        let inst = Instruction {
+            opcode: Opcode::Le,
+            dst: Some(Register { n: 0 }),
+            src: None,
+            off: None,
+            imm: None,
+            span: 0..8,
+        };
+        let result = validate_endian(&inst);
         assert!(result.is_err());
         if let Err(SBPFError::BytecodeError { error, .. }) = result {
             assert_eq!(
@@ -635,9 +690,91 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_binary_immediate_missing_imm() {
+    fn test_validate_endian_has_src() {
         let inst = Instruction {
             opcode: Opcode::Le,
+            dst: Some(Register { n: 0 }),
+            src: Some(Register { n: 1 }),
+            off: None,
+            imm: Some(Either::Right(Number::Int(16))),
+            span: 0..8,
+        };
+        let result = validate_endian(&inst);
+        assert!(result.is_err());
+        if let Err(SBPFError::BytecodeError { error, .. }) = result {
+            assert_eq!(
+                error,
+                format!(
+                    "{} instruction requires destination register and immediate value",
+                    Opcode::Le
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_endian_has_offset() {
+        let inst = Instruction {
+            opcode: Opcode::Be,
+            dst: Some(Register { n: 0 }),
+            src: None,
+            off: Some(Either::Right(10)),
+            imm: Some(Either::Right(Number::Int(64))),
+            span: 0..8,
+        };
+        let result = validate_endian(&inst);
+        assert!(result.is_err());
+        if let Err(SBPFError::BytecodeError { error, .. }) = result {
+            assert_eq!(
+                error,
+                format!(
+                    "{} instruction requires destination register and immediate value",
+                    Opcode::Be
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_binary_immediate_valid() {
+        let valid_inst = Instruction {
+            opcode: Opcode::Add64Imm,
+            dst: Some(Register { n: 0 }),
+            src: None,
+            off: None,
+            imm: Some(Either::Right(Number::Int(42))),
+            span: 0..8,
+        };
+        assert!(validate_binary_immediate(&valid_inst).is_ok());
+    }
+
+    #[test]
+    fn test_validate_binary_immediate_missing_dst() {
+        let inst = Instruction {
+            opcode: Opcode::Add64Imm,
+            dst: None,
+            src: None,
+            off: None,
+            imm: Some(Either::Right(Number::Int(42))),
+            span: 0..8,
+        };
+        let result = validate_binary_immediate(&inst);
+        assert!(result.is_err());
+        if let Err(SBPFError::BytecodeError { error, .. }) = result {
+            assert_eq!(
+                error,
+                format!(
+                    "{} instruction requires destination register and immediate value",
+                    Opcode::Add64Imm
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_binary_immediate_missing_imm() {
+        let inst = Instruction {
+            opcode: Opcode::Add64Imm,
             dst: Some(Register { n: 0 }),
             src: None,
             off: None,
@@ -651,7 +788,7 @@ mod tests {
                 error,
                 format!(
                     "{} instruction requires destination register and immediate value",
-                    Opcode::Le
+                    Opcode::Add64Imm
                 )
             );
         }
@@ -660,11 +797,11 @@ mod tests {
     #[test]
     fn test_validate_binary_immediate_has_src() {
         let inst = Instruction {
-            opcode: Opcode::Le,
+            opcode: Opcode::Add64Imm,
             dst: Some(Register { n: 0 }),
             src: Some(Register { n: 1 }),
             off: None,
-            imm: Some(Either::Right(Number::Int(16))),
+            imm: Some(Either::Right(Number::Int(42))),
             span: 0..8,
         };
         let result = validate_binary_immediate(&inst);
@@ -674,7 +811,7 @@ mod tests {
                 error,
                 format!(
                     "{} instruction requires destination register and immediate value",
-                    Opcode::Le
+                    Opcode::Add64Imm
                 )
             );
         }
@@ -683,7 +820,7 @@ mod tests {
     #[test]
     fn test_validate_binary_immediate_has_offset() {
         let inst = Instruction {
-            opcode: Opcode::Le,
+            opcode: Opcode::Add64Imm,
             dst: Some(Register { n: 0 }),
             src: None,
             off: Some(Either::Right(10)),
@@ -697,7 +834,7 @@ mod tests {
                 error,
                 format!(
                     "{} instruction requires destination register and immediate value",
-                    Opcode::Le
+                    Opcode::Add64Imm
                 )
             );
         }

--- a/crates/vm/src/vm.rs
+++ b/crates/vm/src/vm.rs
@@ -6,10 +6,8 @@ use {
         syscalls::SyscallHandler,
     },
     sbpf_common::{
-        errors::ExecutionError,
-        execute::{self, Vm},
+        errors::ExecutionError, execute::Vm, inst_handler::OPCODE_TO_HANDLER,
         instruction::Instruction,
-        opcode::Opcode,
     },
     serde::{Deserialize, Serialize},
 };
@@ -150,137 +148,12 @@ impl<H: SyscallHandler> SbpfVm<H> {
     }
 
     fn execute_instruction(&mut self, inst: &Instruction) -> SbpfVmResult<()> {
-        match inst.opcode {
-            // ALU 64-bit instructions
-            Opcode::Add64Imm
-            | Opcode::Sub64Imm
-            | Opcode::Mul64Imm
-            | Opcode::Div64Imm
-            | Opcode::Or64Imm
-            | Opcode::And64Imm
-            | Opcode::Lsh64Imm
-            | Opcode::Rsh64Imm
-            | Opcode::Mod64Imm
-            | Opcode::Xor64Imm
-            | Opcode::Mov64Imm
-            | Opcode::Arsh64Imm => execute::execute_binary_immediate(self, inst)?,
-            Opcode::Add64Reg
-            | Opcode::Sub64Reg
-            | Opcode::Mul64Reg
-            | Opcode::Div64Reg
-            | Opcode::Or64Reg
-            | Opcode::And64Reg
-            | Opcode::Lsh64Reg
-            | Opcode::Rsh64Reg
-            | Opcode::Mod64Reg
-            | Opcode::Xor64Reg
-            | Opcode::Mov64Reg
-            | Opcode::Arsh64Reg => execute::execute_binary_register(self, inst)?,
-
-            // ALU 32-bit instructions
-            Opcode::Add32Imm
-            | Opcode::Sub32Imm
-            | Opcode::Mul32Imm
-            | Opcode::Div32Imm
-            | Opcode::Or32Imm
-            | Opcode::And32Imm
-            | Opcode::Lsh32Imm
-            | Opcode::Rsh32Imm
-            | Opcode::Mod32Imm
-            | Opcode::Xor32Imm
-            | Opcode::Mov32Imm
-            | Opcode::Arsh32Imm => execute::execute_binary_immediate(self, inst)?,
-            Opcode::Add32Reg
-            | Opcode::Sub32Reg
-            | Opcode::Mul32Reg
-            | Opcode::Div32Reg
-            | Opcode::Or32Reg
-            | Opcode::And32Reg
-            | Opcode::Lsh32Reg
-            | Opcode::Rsh32Reg
-            | Opcode::Mod32Reg
-            | Opcode::Xor32Reg
-            | Opcode::Mov32Reg
-            | Opcode::Arsh32Reg => execute::execute_binary_register(self, inst)?,
-
-            // Unary and endian instructions
-            Opcode::Neg64 | Opcode::Neg32 | Opcode::Le | Opcode::Be => {
-                execute::execute_unary(self, inst)?
-            }
-
-            // Load instructions
-            Opcode::Lddw => execute::execute_load_immediate(self, inst)?,
-            Opcode::Ldxb | Opcode::Ldxh | Opcode::Ldxw | Opcode::Ldxdw => {
-                execute::execute_load_memory(self, inst)?
-            }
-
-            // Store immediate instructions
-            Opcode::Stb | Opcode::Sth | Opcode::Stw | Opcode::Stdw => {
-                execute::execute_store_immediate(self, inst)?
-            }
-
-            // Store register instructions
-            Opcode::Stxb | Opcode::Stxh | Opcode::Stxw | Opcode::Stxdw => {
-                execute::execute_store_register(self, inst)?
-            }
-
-            // Jump instructions
-            Opcode::Ja => execute::execute_jump(self, inst)?,
-            Opcode::JeqImm
-            | Opcode::JgtImm
-            | Opcode::JgeImm
-            | Opcode::JltImm
-            | Opcode::JleImm
-            | Opcode::JsetImm
-            | Opcode::JneImm
-            | Opcode::JsgtImm
-            | Opcode::JsgeImm
-            | Opcode::JsltImm
-            | Opcode::JsleImm
-            | Opcode::Jeq32Imm
-            | Opcode::Jgt32Imm
-            | Opcode::Jge32Imm
-            | Opcode::Jlt32Imm
-            | Opcode::Jle32Imm
-            | Opcode::Jset32Imm
-            | Opcode::Jne32Imm
-            | Opcode::Jsgt32Imm
-            | Opcode::Jsge32Imm
-            | Opcode::Jslt32Imm
-            | Opcode::Jsle32Imm => execute::execute_jump_immediate(self, inst)?,
-            Opcode::JeqReg
-            | Opcode::JgtReg
-            | Opcode::JgeReg
-            | Opcode::JltReg
-            | Opcode::JleReg
-            | Opcode::JsetReg
-            | Opcode::JneReg
-            | Opcode::JsgtReg
-            | Opcode::JsgeReg
-            | Opcode::JsltReg
-            | Opcode::JsleReg
-            | Opcode::Jeq32Reg
-            | Opcode::Jgt32Reg
-            | Opcode::Jge32Reg
-            | Opcode::Jlt32Reg
-            | Opcode::Jle32Reg
-            | Opcode::Jset32Reg
-            | Opcode::Jne32Reg
-            | Opcode::Jsgt32Reg
-            | Opcode::Jsge32Reg
-            | Opcode::Jslt32Reg
-            | Opcode::Jsle32Reg => execute::execute_jump_register(self, inst)?,
-
-            // Call instructions
-            Opcode::Call => execute::execute_call_immediate(self, inst)?,
-            Opcode::Callx => execute::execute_call_register(self, inst)?,
-
-            // Exit instruction
-            Opcode::Exit => execute::execute_exit(self, inst)?,
-
-            _ => return Err(SbpfVmError::InvalidInstruction),
+        if let Some(handler) = OPCODE_TO_HANDLER.get(&inst.opcode) {
+            (handler.execute)(self, inst)?;
+            Ok(())
+        } else {
+            Err(SbpfVmError::InvalidInstruction)
         }
-        Ok(())
     }
 
     pub fn run(&mut self) -> SbpfVmResult<()> {


### PR DESCRIPTION
### Summary

This mainly contains some refactoring and reorganization related to endian(le/be) operations. Previously, le/be were grouped with binary immediate operations since they shared validation and decode logic, but they had a separate execute_endian function. This technically "worked", but the code was a bit messy and could potentially break too.

We now register endian operations separately in inst_handler giving them their own decode, validate, and execute functions so that we can dispatch cleanly without any messy logic. The validation function for endian operations is also stricter now. The functionality is the same as before and there are no regressions. We can also now simplify `execute_instruction` in vm.rs to just a few lines of code.