### PR TITLE
fix: remove unsupported v2 opcodes from assembler grammar

### DIFF
--- a/crates/assembler/src/sbpf.pest
+++ b/crates/assembler/src/sbpf.pest
@@ -100,7 +100,6 @@ alu_64_op       = {
   | "sub64"
   | "mul64"
   | "div64"
-  | "sdiv64"
   | "mod64"
   | "or64"
   | "and64"
@@ -110,12 +109,6 @@ alu_64_op       = {
   | "rsh64"
   | "arsh64"
   | "hor64"
-  | "lmul64"
-  | "uhmul64"
-  | "udiv64"
-  | "urem64"
-  | "shmul64"
-  | "srem64"
 }
 instr_alu64_imm = { alu_64_op ~ register ~ "," ~ operand }
 instr_alu64_reg = { alu_64_op ~ register ~ "," ~ register }
@@ -126,7 +119,6 @@ alu_32_op       = {
   | "sub32"
   | "mul32"
   | "div32"
-  | "sdiv32"
   | "mod32"
   | "or32"
   | "and32"
@@ -135,10 +127,6 @@ alu_32_op       = {
   | "lsh32"
   | "rsh32"
   | "arsh32"
-  | "lmul32"
-  | "udiv32"
-  | "urem32"
-  | "srem32"
 }
 instr_alu32_imm = { alu_32_op ~ register ~ "," ~ operand }
 instr_alu32_reg = { alu_32_op ~ register ~ "," ~ register }


### PR DESCRIPTION
The assembler accepted v2 opcodes (`udiv64`, `udiv32`, `uhmul64`, `urem64`, `urem32`, `shmul64`, `sdiv64`, `sdiv32`, `srem64`, `srem32`, `lmul64`, `lmul32`) and silently emitted broken bytecode that cannot be executed.

Verified with Mollusk test repo: 
https://github.com/rishavmehra/sbpf-examples/tree/main/arvx-repro

## Fix
Remove the v2 opcodes from `sbpf.pest`. The opcode enum variants are kept so the disassembler can still read deployed v2 programs.

ISSUE -> 
<img width="1280" height="521" alt="telegram-cloud-photo-size-5-6224156010415329335-y" src="https://github.com/user-attachments/assets/901aa4de-2fa0-49a0-9839-112dffa3a486" />

FIX ->
<img width="1165" height="453" alt="image" src="https://github.com/user-attachments/assets/3fd047e5-fc5f-4b9d-8c9a-e45cc7c93a7a" />
