### PR TITLE
fix: exit debugger REPL on EOF instead of spinning

### DIFF
--- a/crates/debugger/src/repl.rs
+++ b/crates/debugger/src/repl.rs
@@ -37,7 +37,7 @@ impl Repl {
             print!("dbg> ");
             io::stdout().flush().unwrap();
             let mut input = String::new();
-            if stdin.read_line(&mut input).is_err() {
+            if stdin.read_line(&mut input).is_err() || input.is_empty() {
                 break;
             }
             let cmd = input.trim();


### PR DESCRIPTION
sbpf-debugger looped forever at 100% CPU on closed/piped stdin - the REPL only broke on read errors, never on EOF (`read_line -> Ok(0)`) Added `Ok(0) => break` Interactive use unchanged.

Issue -> 
<img width="1061" height="404" alt="image" src="https://github.com/user-attachments/assets/5db6033c-80ce-4f61-abd2-cadfced907b0" />

Fix ->
<img width="919" height="100" alt="image" src="https://github.com/user-attachments/assets/94f4bb0a-5ef8-4bda-b750-33513081ef84" />
