### PR TITLE
chores: update dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["development-tools", "command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.86"
-clap = { version = "4.5.13", features = ["derive"] }
-ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+anyhow = "1.0.103"
+clap = { version = "4.6.1", features = ["derive"] }
+ed25519-dalek = { version = "3.0.0", features = ["rand_core"] }
 either = { workspace = true }
-rand = "0.8.5"
+getrandom = { version = "0.4.3", features = ["sys_rng"] }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-codespan-reporting = "0.12.0"
+codespan-reporting = "0.13.1"
 termcolor = "1.4"
 
 sbpf-assembler = { workspace = true }
@@ -31,7 +31,7 @@ sbpf-runtime = { workspace = true }
 sbpf-vm = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.4.1"
+hex-literal = "1.1.0"
 
 [build-dependencies]
 toml = { workspace = true }
@@ -64,37 +64,37 @@ authors = [
 rust-version = "1.90"
 
 [workspace.dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.103"
 base64 = "0.22"
-either = { version = "1.15.0", features = ["serde"] }
+either = { version = "1.16.0", features = ["serde"] }
 num-derive = "0.4"
 num-traits = "0.2"
-gimli = { version = "0.33.0", features = ["write"] }
-object = "0.38.1"
-serde_json = "1.0.122"
+gimli = { version = "0.34.0", features = ["write"] }
+object = "0.39.1"
+serde_json = "1.0.150"
 serde = { version = "1.0", features = ["derive"] }
-smallvec = "1.13"
-thiserror = "2.0.12"
+smallvec = "1.15"
+thiserror = "2.0.18"
 bs58 = "0.5"
-sha2 = "0.10"
-sha3 = "0.10"
-bincode = "1.3"
-blake3 = { version = "1.8.3", features = ["traits-preview"] }
-toml = "0.8"
+sha2 = "0.11"
+sha3 = "0.12"
+wincode = "0.5.5"
+blake3 = { version = "1.8.5", features = ["traits-preview"] }
+toml = "1.1"
 solana-address = { version = "2.6.1", features = [
     "atomic",
     "decode",
     "curve25519",
 ] }
-solana-account = "3.4.0"
-solana-instruction = "3.3.0"
-solana-rent = "3.0.1"
-solana-clock = "3.0.1"
-solana-epoch-schedule = "3.0.0"
-solana-system-interface = { version = "3.1.0", features = ["bincode"] }
+solana-account = "4.3.1"
+solana-instruction = "3.4.0"
+solana-rent = "4.3.0"
+solana-clock = "3.1.1"
+solana-epoch-schedule = "3.2.0"
+solana-system-interface = { version = "3.2.0", features = ["wincode"] }
 solana-program-pack = "3.1.0"
-solana-last-restart-slot = "3.0.0"
-solana-program-error = "3.0.0"
+solana-last-restart-slot = "3.1.0"
+solana-program-error = "3.0.1"
 solana-native-token = "3.0.0"
 sbpf-assembler = { path = "crates/assembler", version = "0.2.2" }
 sbpf-disassembler = { path = "crates/disassembler", version = "0.2.2" }
@@ -105,5 +105,5 @@ sbpf-runtime = { path = "crates/runtime", version = "0.2.2" }
 sbpf-syscall-map = { path = "crates/sbpf-syscall-map", version = "0.2.2" }
 sbpf-transform = { path = "crates/analyzer", version = "0.2.2" }
 sbpf-vm = { path = "crates/vm", version = "0.2.2" }
-mollusk-svm = "0.13.4"
-mollusk-svm-programs-token = "0.13.1"
+mollusk-svm = "0.14.0"
+mollusk-svm-programs-token = "0.14.0"

--- a/build.rs
+++ b/build.rs
@@ -22,11 +22,12 @@ fn main() {
     let manifest = fs::read_to_string(&manifest_path)
         .unwrap_or_else(|error| panic!("Failed to read {}: {error}", manifest_path.display()));
     let manifest = manifest
-        .parse::<toml::Value>()
+        .parse::<toml::Table>()
         .unwrap_or_else(|error| panic!("Failed to parse {}: {error}", manifest_path.display()));
     let workspace_dependencies = manifest
         .get("workspace")
         .and_then(|workspace| workspace.get("dependencies"))
+        .and_then(toml::Value::as_table)
         .unwrap_or_else(|| {
             panic!(
                 "Missing [workspace.dependencies] in {}",
@@ -46,7 +47,7 @@ fn main() {
     }
 }
 
-fn dependency_version<'a>(dependencies: &'a toml::Value, dependency_name: &str) -> Option<&'a str> {
+fn dependency_version<'a>(dependencies: &'a toml::Table, dependency_name: &str) -> Option<&'a str> {
     match dependencies.get(dependency_name)? {
         toml::Value::String(version) => Some(version),
         toml::Value::Table(dependency) => dependency.get("version")?.as_str(),

--- a/crates/assembler/Cargo.toml
+++ b/crates/assembler/Cargo.toml
@@ -22,21 +22,21 @@ anyhow = { workspace = true }
 sbpf-common = { workspace = true }
 sbpf-transform = { workspace = true }
 sbpf-ir = { workspace = true }
-phf = "0.13.1"
-phf_macros = "0.13.1"
-pest = "2.7"
-pest_derive = "2.7"
+phf = "0.14.0"
+phf_macros = "0.14.0"
+pest = "2.8"
+pest_derive = "2.8"
 gimli = { workspace = true, features = ["write"] }
 codespan = "0.13.1"
 sbpf-syscall-map = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.126", features = ["serde-serialize"] }
 serde-wasm-bindgen = "0.6.5"
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 blake3 = "1"
-toml = "0.8"
-serde = { version = "1.0.219", features = ["derive"] }
+toml = "1.1"
+serde = { version = "1.0.228", features = ["derive"] }
 object = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = { workspace = true }
 thiserror = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
 sbpf-syscall-map = { workspace = true }
-once_cell = "1.21.3"
+once_cell = "1.21.4"
 
 [dev-dependencies]
-hex-literal = "1.0.0"
+hex-literal = "1.1.0"

--- a/crates/disassembler/Cargo.toml
+++ b/crates/disassembler/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2.0.18"
 serde = { version = "1.0.228", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.110", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.126", features = ["serde-serialize"] }
 serde-wasm-bindgen = "0.6.5"
 
 [dev-dependencies]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -16,7 +16,6 @@ name = "sbpf_runtime"
 
 [dependencies]
 base64 = { workspace = true }
-bincode = { workspace = true }
 blake3 = { workspace = true }
 bs58 = { workspace = true }
 either = { workspace = true }
@@ -34,6 +33,7 @@ solana-epoch-schedule = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-system-interface = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 solana-program-pack = { workspace = true }

--- a/crates/runtime/src/cpi/builtins/system.rs
+++ b/crates/runtime/src/cpi/builtins/system.rs
@@ -24,7 +24,7 @@ pub fn process(
         ));
     }
 
-    let ix: SystemInstruction = bincode::deserialize(&instruction.data)
+    let ix: SystemInstruction = wincode::deserialize(&instruction.data)
         .map_err(|_| RuntimeError::BuiltinError("invalid system instruction data".into()))?;
 
     match ix {
@@ -400,7 +400,7 @@ mod tests {
         CpiRequest {
             program_id: system_program::ID,
             accounts,
-            data: bincode::serialize(ix).unwrap(),
+            data: wincode::serialize(ix).unwrap(),
             caller_accounts: Vec::new(),
             signers: Vec::new(),
         }

--- a/crates/runtime/src/cpi/mod.rs
+++ b/crates/runtime/src/cpi/mod.rs
@@ -374,7 +374,7 @@ mod tests {
                     is_writable: true,
                 },
             ],
-            data: bincode::serialize(&SystemInstruction::Transfer { lamports: 400_000 }).unwrap(),
+            data: wincode::serialize(&SystemInstruction::Transfer { lamports: 400_000 }).unwrap(),
             caller_accounts: Vec::new(),
             signers: Vec::new(),
         };

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -7,7 +7,7 @@ use {
         term,
     },
     ed25519_dalek::SigningKey,
-    rand::rngs::OsRng,
+    getrandom::{SysRng, rand_core::UnwrapErr},
     sbpf_assembler::{
         AssembleErrors, Assembler, AssemblerOption, DebugMode, FileRegistry, FsFileResolver,
         SbpfArch, SourceOrigin, errors::CompileError,
@@ -134,7 +134,7 @@ fn emit_assembler_errors(assemble_errors: &AssembleErrors) -> Result<()> {
                     diagnostic = diagnostic.with_notes(notes);
                 }
 
-                term::emit(&mut writer.lock(), &config, &files, &diagnostic)?;
+                term::emit_to_write_style(&mut writer.lock(), &config, &files, &diagnostic)?;
             } else {
                 // File not in registry (shouldn't happen), fall back to text-only
                 eprintln!("error: {}", error);
@@ -256,7 +256,7 @@ pub fn build(args: BuildArgs) -> Result<()> {
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("program");
-        let mut rng = OsRng;
+        let mut rng = UnwrapErr(SysRng);
         fs::write(
             deploy_path.join(format!("{}-keypair.json", project_name)),
             serde_json::json!(SigningKey::generate(&mut rng).to_keypair_bytes()[..]).to_string(),

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -5,7 +5,7 @@ use {
     anyhow::{Error, Result},
     clap::Args,
     ed25519_dalek::SigningKey,
-    rand::rngs::OsRng,
+    getrandom::{SysRng, rand_core::UnwrapErr},
     std::{
         fs,
         io::{self, Write},
@@ -79,7 +79,7 @@ pub fn init(args: InitArgs) -> Result<(), Error> {
             PROGRAM,
         )?;
 
-        let mut rng = OsRng;
+        let mut rng = UnwrapErr(SysRng);
         fs::write(
             project_path
                 .join("deploy")


### PR DESCRIPTION
other than routine manifest-only bumps, 

  - Migrated system instruction encoding from `bincode` to `wincode` for the updated Solana system interface feature set.
  - Replaced `rand::rngs::OsRng` with `getrandom::SysRng` wrapped in to satisfy `ed25519-dalek` 3.x key generation requirements.
  - Updated the build script for `toml` 1.1 by parsing manifests as `toml::Table` and explicitly extracting [workspace.dependencies].
  - Adjusted diagnostics emission for the newer `codespan-reporting` API by switching from `term::emit` to `term::emit_to_write_style`.