### PR TITLE
fix: update sysvar syscalls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ solana-program-pack = "3.1.0"
 solana-last-restart-slot = "3.1.0"
 solana-program-error = "3.0.1"
 solana-native-token = "3.0.0"
+solana-stake-history = "1.0.0"
+solana-slot-hashes = "3.1.0"
+solana-epoch-rewards = "3.1.0"
 sbpf-assembler = { path = "crates/assembler", version = "0.2.4" }
 sbpf-disassembler = { path = "crates/disassembler", version = "0.2.4" }
 sbpf-debugger = { path = "crates/debugger", version = "0.2.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,17 +90,18 @@ solana-address = { version = "~2.6.1", features = [
 solana-account = "4.3.0"
 solana-instruction = "3.4.0"
 solana-hash = "~4.5.0"
-solana-rent = "4.3.0"
-solana-clock = "3.1.1"
-solana-epoch-schedule = "3.2.0"
+solana-rent = "~4.3.0"
+solana-clock = "~3.1.1"
+solana-epoch-schedule = "~3.2.0"
 solana-system-interface = { version = "3.2.0", features = ["wincode"] }
 solana-program-pack = "3.1.0"
-solana-last-restart-slot = "3.1.0"
+solana-last-restart-slot = "~3.1.0"
 solana-program-error = "3.0.1"
 solana-native-token = "3.0.0"
-solana-stake-history = "1.0.0"
+solana-stake-history = "~1.0.0"
 solana-slot-hashes = "3.1.0"
 solana-epoch-rewards = "3.1.0"
+solana-fee-calculator = "~3.2.2"
 sbpf-assembler = { path = "crates/assembler", version = "0.2.4" }
 sbpf-disassembler = { path = "crates/disassembler", version = "0.2.4" }
 sbpf-debugger = { path = "crates/debugger", version = "0.2.4" }

--- a/crates/common/src/syscalls.rs
+++ b/crates/common/src/syscalls.rs
@@ -19,7 +19,7 @@ pub const REGISTERED_SYSCALLS: &[&str] = &[
     "sol_get_epoch_schedule_sysvar",
     "sol_get_fees_sysvar",
     "sol_get_rent_sysvar",
-    "sol_get_last_restart_slot_sysvar",
+    "sol_get_last_restart_slot",
     "sol_memcpy_",
     "sol_memmove_",
     "sol_memcmp_",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -39,6 +39,7 @@ solana-stake-history = { workspace = true, features = ["wincode", "sysvar"] }
 solana-slot-hashes = { workspace = true, features = ["wincode", "sysvar"] }
 solana-epoch-rewards = { workspace = true, features = ["wincode", "sysvar"] }
 solana-system-interface = { workspace = true }
+solana-fee-calculator = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,10 +28,16 @@ sha3 = { workspace = true }
 solana-address = { workspace = true }
 solana-account = { workspace = true }
 solana-instruction = { workspace = true }
-solana-rent = { workspace = true }
-solana-clock = { workspace = true }
-solana-epoch-schedule = { workspace = true }
-solana-last-restart-slot = { workspace = true }
+solana-rent = { workspace = true, features = ["wincode", "sysvar"] }
+solana-clock = { workspace = true, features = ["wincode", "sysvar"] }
+solana-epoch-schedule = { workspace = true, features = ["wincode", "sysvar"] }
+solana-last-restart-slot = { workspace = true, features = [
+    "wincode",
+    "sysvar",
+] }
+solana-stake-history = { workspace = true, features = ["wincode", "sysvar"] }
+solana-slot-hashes = { workspace = true, features = ["wincode", "sysvar"] }
+solana-epoch-rewards = { workspace = true, features = ["wincode", "sysvar"] }
 solana-system-interface = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -1,6 +1,7 @@
 use {
-    solana_clock::Clock, solana_epoch_schedule::EpochSchedule,
-    solana_last_restart_slot::LastRestartSlot, solana_rent::Rent,
+    solana_clock::Clock, solana_epoch_rewards::EpochRewards, solana_epoch_schedule::EpochSchedule,
+    solana_last_restart_slot::LastRestartSlot, solana_rent::Rent, solana_slot_hashes::SlotHashes,
+    solana_stake_history::StakeHistory,
 };
 
 #[derive(Debug, Clone)]
@@ -22,12 +23,29 @@ impl Default for RuntimeConfig {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct SysvarContext {
     pub clock: Clock,
     pub rent: Rent,
     pub epoch_schedule: EpochSchedule,
     pub last_restart_slot: LastRestartSlot,
+    pub epoch_rewards: EpochRewards,
+    pub slot_hashes: SlotHashes,
+    pub stake_history: StakeHistory,
+}
+
+impl Clone for SysvarContext {
+    fn clone(&self) -> Self {
+        Self {
+            clock: self.clock.clone(),
+            rent: self.rent.clone(),
+            epoch_schedule: self.epoch_schedule.clone(),
+            last_restart_slot: self.last_restart_slot.clone(),
+            epoch_rewards: self.epoch_rewards.clone(),
+            slot_hashes: SlotHashes::new(self.slot_hashes.slot_hashes()),
+            stake_history: self.stake_history.clone(),
+        }
+    }
 }
 
 /// Reference: https://github.com/anza-xyz/agave/blob/master/program-runtime/src/execution_budget.rs

--- a/crates/runtime/src/syscalls/mod.rs
+++ b/crates/runtime/src/syscalls/mod.rs
@@ -153,13 +153,23 @@ impl SyscallHandler for RuntimeSyscallHandler {
                 &self.costs,
                 &self.sysvars,
             ),
-            "sol_get_last_restart_slot_sysvar" => sysvar::sol_get_last_restart_slot_sysvar(
+            "sol_get_last_restart_slot" => sysvar::sol_get_last_restart_slot(
                 registers,
                 memory,
                 &compute,
                 &self.costs,
                 &self.sysvars,
             ),
+            "sol_get_epoch_rewards_sysvar" => sysvar::sol_get_epoch_rewards_sysvar(
+                registers,
+                memory,
+                &compute,
+                &self.costs,
+                &self.sysvars,
+            ),
+            "sol_get_sysvar" => {
+                sysvar::sol_get_sysvar(registers, memory, &compute, &self.costs, &self.sysvars)
+            }
 
             "sol_set_return_data" => {
                 let (result, data) = return_data::sol_set_return_data(

--- a/crates/runtime/src/syscalls/sysvar.rs
+++ b/crates/runtime/src/syscalls/sysvar.rs
@@ -125,6 +125,12 @@ pub fn sol_get_sysvar(
         .map_err(|_| SbpfVmError::SyscallError("sol_get_sysvar: length exceeds usize".into()))?;
     memory.check_writable(var_addr, length_usize)?;
 
+    // Read sysvar ID
+    let id_bytes = memory.read_bytes(sysvar_id_addr, 32)?;
+    let mut id_arr = [0u8; 32];
+    id_arr.copy_from_slice(id_bytes);
+    let sysvar_id = Address::new_from_array(id_arr);
+
     // Check for overflows
     let offset_length = offset.checked_add(length).ok_or_else(|| {
         SbpfVmError::SyscallError("sol_get_sysvar: offset + length overflow".into())
@@ -132,11 +138,6 @@ pub fn sol_get_sysvar(
     let _ = var_addr.checked_add(length).ok_or_else(|| {
         SbpfVmError::SyscallError("sol_get_sysvar: var_addr + length overflow".into())
     })?;
-
-    let id_bytes = memory.read_bytes(sysvar_id_addr, 32)?;
-    let mut id_arr = [0u8; 32];
-    id_arr.copy_from_slice(id_bytes);
-    let sysvar_id = Address::new_from_array(id_arr);
 
     let serialized = if sysvar_id == solana_clock::sysvar::ID {
         wincode::serialize(&sysvars.clock)

--- a/crates/runtime/src/syscalls/sysvar.rs
+++ b/crates/runtime/src/syscalls/sysvar.rs
@@ -1,7 +1,13 @@
 use {
     crate::config::{ExecutionCost, SysvarContext},
-    sbpf_vm::{compute::ComputeMeter, errors::SbpfVmResult, memory::Memory},
+    sbpf_vm::{
+        compute::ComputeMeter,
+        errors::{SbpfVmError, SbpfVmResult},
+        memory::Memory,
+    },
+    solana_address::Address,
     solana_clock::Clock,
+    solana_epoch_rewards::EpochRewards,
     solana_epoch_schedule::EpochSchedule,
     solana_last_restart_slot::LastRestartSlot,
     solana_rent::Rent,
@@ -62,7 +68,7 @@ pub fn sol_get_epoch_schedule_sysvar(
     Ok(0)
 }
 
-pub fn sol_get_last_restart_slot_sysvar(
+pub fn sol_get_last_restart_slot(
     registers: [u64; 5],
     memory: &mut Memory,
     compute: &ComputeMeter,
@@ -76,6 +82,91 @@ pub fn sol_get_last_restart_slot_sysvar(
     )?;
     write_sysvar_bytes(memory, registers[0], &sysvars.last_restart_slot)?;
     Ok(0)
+}
+
+pub fn sol_get_epoch_rewards_sysvar(
+    registers: [u64; 5],
+    memory: &mut Memory,
+    compute: &ComputeMeter,
+    costs: &ExecutionCost,
+    sysvars: &SysvarContext,
+) -> SbpfVmResult<u64> {
+    compute.consume(
+        costs
+            .sysvar_base_cost
+            .saturating_add(size_of::<EpochRewards>() as u64),
+    )?;
+    write_sysvar_bytes(memory, registers[0], &sysvars.epoch_rewards)?;
+    Ok(0)
+}
+
+pub fn sol_get_sysvar(
+    registers: [u64; 5],
+    memory: &mut Memory,
+    compute: &ComputeMeter,
+    costs: &ExecutionCost,
+    sysvars: &SysvarContext,
+) -> SbpfVmResult<u64> {
+    let sysvar_id_addr = registers[0];
+    let var_addr = registers[1];
+    let offset = registers[2];
+    let length = registers[3];
+
+    let sysvar_id_cost = 32_u64.checked_div(costs.cpi_bytes_per_unit).unwrap_or(0);
+    let sysvar_buf_cost = length.checked_div(costs.cpi_bytes_per_unit).unwrap_or(0);
+    let cost = costs
+        .sysvar_base_cost
+        .saturating_add(sysvar_id_cost)
+        .saturating_add(sysvar_buf_cost.max(costs.mem_op_base_cost));
+    compute.consume(cost)?;
+
+    // Check if memory region is writable
+    let length_usize = usize::try_from(length)
+        .map_err(|_| SbpfVmError::SyscallError("sol_get_sysvar: length exceeds usize".into()))?;
+    memory.check_writable(var_addr, length_usize)?;
+
+    // Check for overflows
+    let offset_length = offset.checked_add(length).ok_or_else(|| {
+        SbpfVmError::SyscallError("sol_get_sysvar: offset + length overflow".into())
+    })?;
+    let _ = var_addr.checked_add(length).ok_or_else(|| {
+        SbpfVmError::SyscallError("sol_get_sysvar: var_addr + length overflow".into())
+    })?;
+
+    let id_bytes = memory.read_bytes(sysvar_id_addr, 32)?;
+    let mut id_arr = [0u8; 32];
+    id_arr.copy_from_slice(id_bytes);
+    let sysvar_id = Address::new_from_array(id_arr);
+
+    let serialized = if sysvar_id == solana_clock::sysvar::ID {
+        wincode::serialize(&sysvars.clock)
+    } else if sysvar_id == solana_rent::sysvar::ID {
+        wincode::serialize(&sysvars.rent)
+    } else if sysvar_id == solana_epoch_schedule::sysvar::ID {
+        wincode::serialize(&sysvars.epoch_schedule)
+    } else if sysvar_id == solana_last_restart_slot::sysvar::ID {
+        wincode::serialize(&sysvars.last_restart_slot)
+    } else if sysvar_id == solana_epoch_rewards::sysvar::ID {
+        wincode::serialize(&sysvars.epoch_rewards)
+    } else if sysvar_id == solana_slot_hashes::sysvar::ID {
+        wincode::serialize(&sysvars.slot_hashes)
+    } else if sysvar_id == solana_stake_history::sysvar::ID {
+        wincode::serialize(&sysvars.stake_history)
+    } else {
+        // sysvar not found
+        return Ok(2);
+    };
+    let buf = serialized.map_err(|error| {
+        SbpfVmError::SyscallError(format!("failed to serialize sysvar: {error}"))
+    })?;
+
+    if let Some(slice) = buf.get(offset as usize..offset_length as usize) {
+        memory.write_bytes(var_addr, slice)?;
+        Ok(0)
+    } else {
+        // offset length exceeds sysvar
+        Ok(1)
+    }
 }
 
 #[cfg(test)]
@@ -172,14 +263,14 @@ mod tests {
     }
 
     #[test]
-    fn test_sol_get_last_restart_slot_sysvar() {
+    fn test_sol_get_last_restart_slot() {
         let mut memory = make_memory();
         let mut sysvars = SysvarContext::default();
         sysvars.last_restart_slot.last_restart_slot = 12_345_678;
 
         let addr = Memory::HEAP_START;
         let registers = [addr, 0, 0, 0, 0];
-        sol_get_last_restart_slot_sysvar(
+        sol_get_last_restart_slot(
             registers,
             &mut memory,
             &meter(1_000_000),
@@ -192,5 +283,97 @@ mod tests {
             .read_bytes(addr, size_of::<LastRestartSlot>())
             .unwrap();
         assert_eq!(written, raw_bytes(&sysvars.last_restart_slot).as_slice());
+    }
+
+    #[test]
+    fn test_sol_get_epoch_rewards_sysvar() {
+        let mut memory = make_memory();
+        let mut sysvars = SysvarContext::default();
+        sysvars.epoch_rewards.total_rewards = 111_000;
+        sysvars.epoch_rewards.active = true;
+
+        let addr = Memory::HEAP_START;
+        let registers = [addr, 0, 0, 0, 0];
+        sol_get_epoch_rewards_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+
+        let written = memory.read_bytes(addr, size_of::<EpochRewards>()).unwrap();
+        assert_eq!(written, raw_bytes(&sysvars.epoch_rewards).as_slice());
+    }
+
+    #[test]
+    fn test_sol_get_sysvar() {
+        let mut memory = make_memory();
+        let sysvars = SysvarContext::default();
+        let expected = wincode::serialize(&sysvars.rent).unwrap();
+        assert_eq!(expected.len(), 17);
+
+        let id_addr = Memory::HEAP_START;
+        let var_addr = Memory::HEAP_START + 64;
+
+        // Get the rent sysvar
+        memory
+            .write_bytes(id_addr, solana_rent::sysvar::ID.as_ref())
+            .unwrap();
+
+        let registers = [id_addr, var_addr, 0, expected.len() as u64, 0];
+        let compute = meter(1_000_000);
+        let ret = sol_get_sysvar(registers, &mut memory, &compute, &costs(), &sysvars).unwrap();
+        assert_eq!(ret, 0);
+        assert_eq!(
+            memory.read_bytes(var_addr, expected.len()).unwrap(),
+            expected.as_slice()
+        );
+        // cost: sysvar_base_cost(100) + 32/250(0) + max(17/250(0), mem_op_base_cost(10)) = 110
+        assert_eq!(compute.get_consumed(), 110);
+    }
+
+    #[test]
+    fn test_sol_get_sysvar_not_found() {
+        let mut memory = make_memory();
+        let sysvars = SysvarContext::default();
+        let id_addr = Memory::HEAP_START;
+        let var_addr = Memory::HEAP_START + 64;
+        memory.write_bytes(id_addr, &[0u8; 32]).unwrap();
+
+        let registers = [id_addr, var_addr, 0, 8, 0];
+        let ret = sol_get_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+        assert_eq!(ret, 2);
+    }
+
+    #[test]
+    fn test_sol_get_sysvar_offset_length_exceeds() {
+        let mut memory = make_memory();
+        let sysvars = SysvarContext::default();
+        let id_addr = Memory::HEAP_START;
+        let var_addr = Memory::HEAP_START + 64;
+        memory
+            .write_bytes(id_addr, solana_rent::sysvar::ID.as_ref())
+            .unwrap();
+
+        // rent is 17 bytes, so offset 16 + length 8 should exceed
+        let registers = [id_addr, var_addr, 16, 8, 0];
+        let ret = sol_get_sysvar(
+            registers,
+            &mut memory,
+            &meter(1_000_000),
+            &costs(),
+            &sysvars,
+        )
+        .unwrap();
+        assert_eq!(ret, 1);
     }
 }

--- a/crates/vm/src/memory.rs
+++ b/crates/vm/src/memory.rs
@@ -91,11 +91,10 @@ impl Memory {
             MemoryRegion::Heap => &self.heap,
         };
 
-        if offset + len > data.len() {
-            return Err(SbpfVmError::MemoryOutOfBounds(offset as u64, len));
-        }
-
-        Ok(&data[offset..offset + len])
+        offset
+            .checked_add(len)
+            .and_then(|end| data.get(offset..end))
+            .ok_or(SbpfVmError::MemoryOutOfBounds(offset as u64, len))
     }
 
     fn get_slice_mut(
@@ -118,11 +117,10 @@ impl Memory {
             MemoryRegion::Rodata => unreachable!(),
         };
 
-        if offset + len > data.len() {
-            return Err(SbpfVmError::MemoryOutOfBounds(offset as u64, len));
-        }
-
-        Ok(&mut data[offset..offset + len])
+        offset
+            .checked_add(len)
+            .and_then(|end| data.get_mut(offset..end))
+            .ok_or(SbpfVmError::MemoryOutOfBounds(offset as u64, len))
     }
 
     pub fn read_u8(&self, addr: u64) -> SbpfVmResult<u8> {

--- a/crates/vm/src/memory.rs
+++ b/crates/vm/src/memory.rs
@@ -198,6 +198,12 @@ impl Memory {
         Ok(())
     }
 
+    pub fn check_writable(&mut self, addr: u64, len: usize) -> SbpfVmResult<()> {
+        let (region, offset) = self.translate(addr)?;
+        let _ = self.get_slice_mut(region, offset, len)?;
+        Ok(())
+    }
+
     pub fn alloc(&mut self, size: usize) -> SbpfVmResult<u64> {
         if self.heap_ptr + size > self.heap.len() {
             return Err(SbpfVmError::MemoryOutOfBounds(


### PR DESCRIPTION
### Summary

- Add missing sysvar syscalls `sol_get_epoch_rewards_sysvar` and `sol_get_sysvar`
- Rename `sol_get_last_restart_slot_sysvar` to `sol_get_last_restart_slot`