### PR TITLE
chore: cleanup dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ sbpf-disassembler = { workspace = true }
 sbpf-debugger = { workspace = true }
 sbpf-runtime = { workspace = true }
 sbpf-vm = { workspace = true }
-solana-hash = { workspace = true }
 
 [dev-dependencies]
 hex-literal = "1.1.0"
@@ -79,29 +78,27 @@ thiserror = "2.0.18"
 bs58 = "0.5"
 sha2 = "0.11.0"
 sha3 = "0.12.0"
-wincode = "0.5.5"
+wincode = "0.6.0"
 blake3 = { version = "1.8.5", features = ["traits-preview"] }
 toml = "1.1.3"
-solana-address = { version = "~2.6.1", features = [
+solana-address = { version = "2.7.0", features = [
     "atomic",
     "decode",
     "curve25519",
 ] }
-solana-account = "4.3.0"
-solana-instruction = "3.4.0"
-solana-hash = "~4.5.0"
-solana-rent = "~4.3.0"
-solana-clock = "~3.1.1"
-solana-epoch-schedule = "~3.2.0"
+solana-account = "4.4.0"
+solana-instruction = "3.5.0"
+solana-rent = "4.4.0"
+solana-clock = "3.2.0"
+solana-epoch-schedule = "3.3.0"
 solana-system-interface = { version = "3.2.0", features = ["wincode"] }
 solana-program-pack = "3.1.0"
-solana-last-restart-slot = "~3.1.0"
+solana-last-restart-slot = "3.2.0"
 solana-program-error = "3.0.1"
 solana-native-token = "3.0.0"
-solana-stake-history = "~1.0.0"
-solana-slot-hashes = "3.1.0"
-solana-epoch-rewards = "3.1.0"
-solana-fee-calculator = "~3.2.2"
+solana-stake-history = "1.1.0"
+solana-slot-hashes = "3.2.0"
+solana-epoch-rewards = "3.2.0"
 sbpf-assembler = { path = "crates/assembler", version = "0.2.4" }
 sbpf-disassembler = { path = "crates/disassembler", version = "0.2.4" }
 sbpf-debugger = { path = "crates/debugger", version = "0.2.4" }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -39,7 +39,6 @@ solana-stake-history = { workspace = true, features = ["wincode", "sysvar"] }
 solana-slot-hashes = { workspace = true, features = ["wincode", "sysvar"] }
 solana-epoch-rewards = { workspace = true, features = ["wincode", "sysvar"] }
 solana-system-interface = { workspace = true }
-solana-fee-calculator = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
### Summary

- Update pinned dependencies to latest versions
- Remove `solana-hash` and `solana-fee-calculator` from dependencies (they aren't really used and were added to temporarily get around the conflict)