### PR TITLE
feat: add tablegen macro for opcode handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sbpf-common-derive"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sbpf-common-tablegen",
+ "syn 2.0.119",
+ "trybuild",
+]
+
+[[package]]
+name = "sbpf-common-tablegen"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "sbpf-debugger"
 version = "0.3.0"
 dependencies = [
@@ -3837,6 +3857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,6 +4026,21 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "trybuild"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.4+spec-1.1.0",
+]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ members = [
     "crates/analyzer",
     "crates/assembler",
     "crates/common",
+    "crates/common/macros/derive",
+    "crates/common/macros/tablegen",
     "crates/disassembler",
     "crates/debugger",
     "crates/ir",
@@ -108,5 +110,10 @@ sbpf-runtime = { path = "crates/runtime", version = "0.3.0" }
 sbpf-syscall-map = { path = "crates/syscall-map", version = "0.3.0" }
 sbpf-analyze = { path = "crates/analyzer", version = "0.3.0" }
 sbpf-vm = { path = "crates/vm", version = "0.3.0" }
+sbpf-common-derive = { path = "crates/common/macros/derive", version = "0.3.0" }
+sbpf-common-tablegen = { path = "crates/common/macros/tablegen", version = "0.3.0" }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["extra-traits", "full"] }
 mollusk-svm = "0.14.0"
 mollusk-svm-programs-token = "0.14.0"

--- a/crates/common/macros/derive/Cargo.toml
+++ b/crates/common/macros/derive/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "sbpf-common-derive"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Proc macros for sbpf-common opcode table generation"
+keywords = ["solana", "bpf", "blockchain"]
+categories = ["development-tools"]
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+name = "sbpf_common_derive"
+
+[dependencies]
+sbpf-common-tablegen = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+trybuild = "1"

--- a/crates/common/macros/derive/src/lib.rs
+++ b/crates/common/macros/derive/src/lib.rs
@@ -1,0 +1,20 @@
+use {
+    proc_macro::TokenStream,
+    syn::{DeriveInput, parse_macro_input},
+};
+
+#[proc_macro_derive(OpcodeTable, attributes(opcode))]
+pub fn derive_opcode_table(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    sbpf_common_tablegen::derive_opcode_table(&input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+#[proc_macro_derive(OpcodeGroup, attributes(group, handlers))]
+pub fn derive_opcode_group(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    sbpf_common_tablegen::derive_opcode_group(&input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}

--- a/crates/common/macros/derive/tests/compile.rs
+++ b/crates/common/macros/derive/tests/compile.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn compile_pass() {
+        let t = trybuild::TestCases::new();
+        t.pass("tests/fixtures/compile_pass.rs");
+    }
+
+    #[test]
+    fn compile_fail() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/fixtures/compile_fail.rs");
+    }
+}

--- a/crates/common/macros/derive/tests/fixtures/compile_fail.rs
+++ b/crates/common/macros/derive/tests/fixtures/compile_fail.rs
@@ -1,0 +1,129 @@
+use sbpf_common_derive::{OpcodeGroup, OpcodeTable};
+
+#[path = "./handlers.rs"]
+mod handlers;
+
+use handlers::{DecodeFn, ExecuteFn, ValidateFn, stub_decode, stub_execute, stub_validate};
+
+#[derive(Clone, Copy, OpcodeGroup)]
+#[handlers(
+    decode = DecodeFn,
+    validate = ValidateFn,
+    execute = ExecuteFn,
+)]
+pub enum Group {
+    #[group(
+        title = "A",
+        description = "A",
+        decode = stub_decode,
+        validate = stub_validate,
+        execute = stub_execute,
+    )]
+    A,
+}
+
+// Empty OpcodeTable
+#[derive(Clone, Copy, OpcodeTable)]
+pub enum OpcodeEmpty {}
+
+// Empty OpcodeGroup
+#[derive(Clone, Copy, OpcodeGroup)]
+#[handlers(
+    decode = DecodeFn,
+    validate = ValidateFn,
+    execute = ExecuteFn,
+)]
+pub enum GroupEmpty {}
+
+// Missing `doc` field
+#[derive(OpcodeTable)]
+pub enum OpcodeMissingDoc {
+    #[opcode(mnemonic = "x", code = 0x01, group = GroupOk::A)]
+    X,
+}
+
+// `mnemonic` field specified more than once
+#[derive(Clone, Copy, OpcodeTable)]
+pub enum OpcodeRepeatedField {
+    #[opcode(
+        mnemonic = "x",
+        mnemonic = "y",
+        code = 0x01,
+        group = Group::A,
+        doc = "x",
+    )]
+    X,
+}
+
+// Duplicate code (0x01)
+#[derive(OpcodeTable)]
+pub enum OpcodeDuplicateCode {
+    #[opcode(mnemonic = "a", code = 0x01, group = GroupOk::A, doc = "a")]
+    A,
+    #[opcode(mnemonic = "b", code = 0x01, group = GroupOk::A, doc = "b")]
+    B,
+}
+
+// Missing #[handlers(...)] attribute
+#[derive(Clone, Copy, OpcodeGroup)]
+pub enum GroupMissingHandlers {
+    #[group(
+        title = "A",
+        description = "A",
+        decode = stub_decode,
+        validate = stub_validate,
+        execute = stub_execute,
+    )]
+    A,
+}
+
+// No decode, validate, and execute handlers
+#[derive(OpcodeGroup)]
+#[handlers(
+    decode = DecodeFn,
+    validate = ValidateFn,
+    execute = ExecuteFn,
+)]
+pub enum GroupMissingFns {
+    #[group(title = "A", description = "Group A")]
+    A,
+}
+
+// Wrong handler signature (expected handlers::DecodeFn)
+fn bad_decode(_: i32) {}
+
+#[derive(Clone, Copy, OpcodeGroup)]
+#[handlers(
+    decode = DecodeFn,
+    validate = ValidateFn,
+    execute = ExecuteFn,
+)]
+pub enum GroupWrongHandlerSignature {
+    #[group(
+        title = "A",
+        description = "A",
+        decode = bad_decode,
+        validate = stub_validate,
+        execute = stub_execute,
+    )]
+    A,
+}
+
+// No OpcodeGroup trait implemented
+#[derive(Clone, Copy)]
+pub enum InvalidOpcodeGroup {
+    A,
+}
+
+#[derive(Clone, Copy, OpcodeTable)]
+pub enum OpcodeWrongGroup {
+    #[opcode(
+        mnemonic = "a",
+        code = 0x01,
+        group = InvalidOpcodeGroup::A,
+        doc = "a",
+    )]
+    A,
+}
+
+fn main() {}

--- a/crates/common/macros/derive/tests/fixtures/compile_fail.stderr
+++ b/crates/common/macros/derive/tests/fixtures/compile_fail.stderr
@@ -1,0 +1,79 @@
+error: OpcodeTable requires at least one opcode variant
+  --> tests/fixtures/compile_fail.rs:27:10
+   |
+27 | pub enum OpcodeEmpty {}
+   |          ^^^^^^^^^^^
+
+error: OpcodeGroup requires at least one group variant
+  --> tests/fixtures/compile_fail.rs:36:10
+   |
+36 | pub enum GroupEmpty {}
+   |          ^^^^^^^^^^
+
+error: missing required field `doc`
+  --> tests/fixtures/compile_fail.rs:42:5
+   |
+42 |     X,
+   |     ^
+
+error: `mnemonic` specified more than once
+  --> tests/fixtures/compile_fail.rs:50:9
+   |
+50 |         mnemonic = "y",
+   |         ^^^^^^^^
+
+error: duplicate code found for opcodes `A` and `B`: 0x01
+  --> tests/fixtures/compile_fail.rs:64:5
+   |
+64 |     B,
+   |     ^
+
+error: OpcodeGroup requires #[handlers(...)]
+  --> tests/fixtures/compile_fail.rs:69:10
+   |
+69 | pub enum GroupMissingHandlers {
+   |          ^^^^^^^^^^^^^^^^^^^^
+
+error: missing required field `decode`
+  --> tests/fixtures/compile_fail.rs:89:5
+   |
+89 |     A,
+   |     ^
+
+error[E0277]: the trait bound `InvalidOpcodeGroup: OpcodeGroup` is not satisfied
+   --> tests/fixtures/compile_fail.rs:123:17
+    |
+123 |         group = InvalidOpcodeGroup::A,
+    |                 ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+help: the trait `OpcodeGroup` is not implemented for `InvalidOpcodeGroup`
+   --> tests/fixtures/compile_fail.rs:114:1
+    |
+114 | pub enum InvalidOpcodeGroup {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: the following other types implement trait `OpcodeGroup`
+   --> tests/fixtures/compile_fail.rs:8:23
+    |
+  8 | #[derive(Clone, Copy, OpcodeGroup)]
+    |                       ^^^^^^^^^^^ `Group`
+...
+ 95 | #[derive(Clone, Copy, OpcodeGroup)]
+    |                       ^^^^^^^^^^^ `GroupWrongHandlerSignature`
+note: required by a bound in `sbpf_common_tablegen::OpcodeTable::Group`
+   --> $WORKSPACE/crates/common/macros/tablegen/src/lib.rs
+    |
+    |     type Group: OpcodeGroup;
+    |                 ^^^^^^^^^^^ required by this bound in `OpcodeTable::Group`
+    = note: this error originates in the derive macro `OpcodeGroup` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+   --> tests/fixtures/compile_fail.rs:105:18
+    |
+ 95 | #[derive(Clone, Copy, OpcodeGroup)]
+    |                       ----------- expected `fn()` because of return type
+...
+105 |         decode = bad_decode,
+    |                  ^^^^^^^^^^ incorrect number of function parameters
+    |
+    = note: expected fn pointer `fn()`
+                  found fn item `fn(i32) {bad_decode}`

--- a/crates/common/macros/derive/tests/fixtures/compile_pass.rs
+++ b/crates/common/macros/derive/tests/fixtures/compile_pass.rs
@@ -1,0 +1,154 @@
+use sbpf_common_derive::{OpcodeGroup, OpcodeTable};
+use sbpf_common_tablegen::{OpcodeGroup as _, OpcodeTable as _};
+use std::str::FromStr;
+
+#[path = "./handlers.rs"]
+mod handlers;
+
+use handlers::{
+    DecodeFn, ExecuteFn, ValidateFn, stub_decode, stub_decode_b, stub_execute, stub_execute_b,
+    stub_validate, stub_validate_b,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, OpcodeTable)]
+pub enum Opcode {
+    #[opcode(mnemonic = "x", code = 0x01, group = Group::A, doc = "op x")]
+    X,
+
+    #[opcode(mnemonic = "y", code = 0x02, group = Group::A, doc = "op y")]
+    Y,
+
+    #[opcode(
+        mnemonic = "z",
+        code = 0x03,
+        group = Group::B,
+        doc = "op z",
+        arch = v3,
+    )]
+    Z,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, OpcodeGroup)]
+#[handlers(
+    decode = DecodeFn,
+    validate = ValidateFn,
+    execute = ExecuteFn,
+)]
+pub enum Group {
+    #[group(
+        title = "A",
+        description = "Group A",
+        decode = stub_decode,
+        validate = stub_validate,
+        execute = stub_execute,
+    )]
+    A,
+    #[group(
+        title = "B",
+        description = "Group B",
+        decode = stub_decode_b,
+        validate = stub_validate_b,
+        execute = stub_execute_b,
+    )]
+    B,
+}
+
+fn main() {
+    // Check if OpcodeTable trait is implementated correctly.
+    assert_eq!(Opcode::from_str("x").unwrap(), Opcode::X);
+    assert_eq!(Opcode::from_str("y").unwrap(), Opcode::Y);
+    assert_eq!(Opcode::from_str("z").unwrap(), Opcode::Z);
+    assert!(Opcode::from_str("null").is_err());
+
+    assert_eq!(Opcode::X.to_str(), "x");
+    assert_eq!(Opcode::Y.to_str(), "y");
+    assert_eq!(Opcode::Z.to_str(), "z");
+
+    assert_eq!(format!("{}", Opcode::X), "x");
+    assert_eq!(format!("{}", Opcode::Y), "y");
+    assert_eq!(format!("{}", Opcode::Z), "z");
+
+    assert_eq!(u8::from(Opcode::X), 0x01);
+    assert_eq!(u8::from(Opcode::Y), 0x02);
+    assert_eq!(u8::from(Opcode::Z), 0x03);
+
+    assert_eq!(Opcode::try_from(0x01u8).unwrap(), Opcode::X);
+    assert_eq!(Opcode::try_from(0x02u8).unwrap(), Opcode::Y);
+    assert_eq!(Opcode::try_from_sbpf_v3(0x03).unwrap(), Opcode::Z);
+    assert!(Opcode::try_from(0x03u8).is_err());
+    assert!(Opcode::try_from(0x04u8).is_err());
+
+    assert_eq!(Opcode::all().len(), 3);
+    assert_eq!(Opcode::X.group(), Group::A);
+    assert_eq!(Opcode::Y.group(), Group::A);
+    assert_eq!(Opcode::Z.group(), Group::B);
+
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::X.group().decode_fn(),
+        stub_decode as DecodeFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::Y.group().decode_fn(),
+        stub_decode as DecodeFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::Z.group().decode_fn(),
+        stub_decode_b as DecodeFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::X.group().validate_fn(),
+        stub_validate as ValidateFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::Y.group().validate_fn(),
+        stub_validate as ValidateFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::Z.group().validate_fn(),
+        stub_validate_b as ValidateFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::X.group().execute_fn(),
+        stub_execute as ExecuteFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::Y.group().execute_fn(),
+        stub_execute as ExecuteFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Opcode::Z.group().execute_fn(),
+        stub_execute_b as ExecuteFn
+    ));
+
+    // Check if OpcodeGroup trait is implementated correctly.
+    assert_eq!(Group::A.title(), "A");
+    assert_eq!(Group::A.description(), "Group A");
+    assert_eq!(Group::B.title(), "B");
+    assert_eq!(Group::B.description(), "Group B");
+    assert_eq!(Group::all().len(), 2);
+
+    assert!(core::ptr::fn_addr_eq(
+        Group::A.decode_fn(),
+        stub_decode as DecodeFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Group::A.validate_fn(),
+        stub_validate as ValidateFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Group::A.execute_fn(),
+        stub_execute as ExecuteFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Group::B.decode_fn(),
+        stub_decode_b as DecodeFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Group::B.validate_fn(),
+        stub_validate_b as ValidateFn
+    ));
+    assert!(core::ptr::fn_addr_eq(
+        Group::B.execute_fn(),
+        stub_execute_b as ExecuteFn
+    ));
+}

--- a/crates/common/macros/derive/tests/fixtures/handlers.rs
+++ b/crates/common/macros/derive/tests/fixtures/handlers.rs
@@ -1,0 +1,11 @@
+pub type DecodeFn = fn();
+pub type ValidateFn = fn();
+pub type ExecuteFn = fn();
+
+pub fn stub_decode() {}
+pub fn stub_validate() {}
+pub fn stub_execute() {}
+
+pub fn stub_decode_b() {}
+pub fn stub_validate_b() {}
+pub fn stub_execute_b() {}

--- a/crates/common/macros/tablegen/Cargo.toml
+++ b/crates/common/macros/tablegen/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sbpf-common-tablegen"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Parser, IR, and other helpers for sBPF opcode table generation"
+keywords = ["solana", "bpf", "blockchain"]
+categories = ["development-tools"]
+rust-version.workspace = true
+
+[lib]
+crate-type = ["lib"]
+name = "sbpf_common_tablegen"
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/crates/common/macros/tablegen/src/error.rs
+++ b/crates/common/macros/tablegen/src/error.rs
@@ -1,0 +1,15 @@
+use {proc_macro2::Span, syn::Error};
+
+pub fn err(span: Span, msg: impl std::fmt::Display) -> Error {
+    Error::new(span, msg)
+}
+
+pub fn combine_errors(errors: Vec<Error>) -> Result<(), Error> {
+    errors
+        .into_iter()
+        .reduce(|mut acc, e| {
+            acc.combine(e);
+            acc
+        })
+        .map_or(Ok(()), Err)
+}

--- a/crates/common/macros/tablegen/src/expand.rs
+++ b/crates/common/macros/tablegen/src/expand.rs
@@ -1,0 +1,307 @@
+use {
+    crate::ir::{OpcodeGroupDef, OpcodeTableDef},
+    proc_macro2::TokenStream,
+    quote::quote,
+    syn::Path,
+};
+
+/// Expand `#[derive(OpcodeTable)]` into conversions and the `OpcodeTable` trait impl.
+pub fn expand_opcode_table(def: &OpcodeTableDef) -> TokenStream {
+    let from_str = expand_from_str(def);
+    let display = expand_display(def);
+    let try_from_u8 = expand_try_from_u8(def);
+    let from_opcode_u8 = expand_from_opcode_for_u8(def);
+    let table_impl = expand_opcode_table_trait(def);
+
+    quote! {
+        #from_str
+        #display
+        #try_from_u8
+        #from_opcode_u8
+        #table_impl
+    }
+}
+
+fn expand_from_str(def: &OpcodeTableDef) -> TokenStream {
+    let enum_name = &def.enum_name;
+    let mut arms = Vec::new();
+
+    for op in &def.opcodes {
+        if !op.is_from_str_target(&def.opcodes) {
+            continue;
+        }
+        let mnemonic = &op.mnemonic;
+        let variant = &op.variant;
+        arms.push(quote! {
+            #mnemonic => Ok(#enum_name::#variant)
+        });
+    }
+
+    quote! {
+        impl ::core::str::FromStr for #enum_name {
+            type Err = &'static str;
+
+            fn from_str(s: &str) -> ::core::result::Result<Self, Self::Err> {
+                match s {
+                    #(#arms,)*
+                    _ => Err("Invalid opcode"),
+                }
+            }
+        }
+    }
+}
+
+fn expand_display(def: &OpcodeTableDef) -> TokenStream {
+    let enum_name = &def.enum_name;
+    quote! {
+        impl ::core::fmt::Display for #enum_name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                write!(
+                    f,
+                    "{}",
+                    <#enum_name as ::sbpf_common_tablegen::OpcodeTable>::to_str(self),
+                )
+            }
+        }
+    }
+}
+
+fn expand_try_from_u8(def: &OpcodeTableDef) -> TokenStream {
+    let enum_name = &def.enum_name;
+    let arms: Vec<_> = def
+        .opcodes
+        .iter()
+        .filter(|op| !op.is_arch_v3())
+        .map(|op| {
+            let code = op.code;
+            let variant = &op.variant;
+            quote! { #code => Ok(#enum_name::#variant) }
+        })
+        .collect();
+
+    quote! {
+        impl ::core::convert::TryFrom<u8> for #enum_name {
+            type Error = ::sbpf_common_tablegen::OpcodeError;
+
+            fn try_from(opcode: u8) -> ::core::result::Result<Self, Self::Error> {
+                match opcode {
+                    #(#arms,)*
+                    _ => Err(::sbpf_common_tablegen::OpcodeError::InvalidOpcode { byte: opcode }),
+                }
+            }
+        }
+    }
+}
+
+fn expand_from_opcode_for_u8(def: &OpcodeTableDef) -> TokenStream {
+    let enum_name = &def.enum_name;
+    let arms: Vec<_> = def
+        .opcodes
+        .iter()
+        .map(|op| {
+            let variant = &op.variant;
+            let code = op.code;
+            quote! { #enum_name::#variant => #code }
+        })
+        .collect();
+
+    quote! {
+        impl ::core::convert::From<#enum_name> for u8 {
+            fn from(opcode: #enum_name) -> Self {
+                match opcode {
+                    #(#arms,)*
+                }
+            }
+        }
+    }
+}
+
+fn expand_opcode_table_trait(def: &OpcodeTableDef) -> TokenStream {
+    let enum_name = &def.enum_name;
+    let group_ty = group_enum_path(
+        &def.opcodes
+            .first()
+            .expect("validated OpcodeTable must not be empty")
+            .group,
+    );
+
+    let to_str_arms: Vec<_> = def
+        .opcodes
+        .iter()
+        .map(|op| {
+            let variant = &op.variant;
+            let mnemonic = &op.mnemonic;
+            quote! { #enum_name::#variant => #mnemonic }
+        })
+        .collect();
+
+    let v3_arms: Vec<_> = def
+        .opcodes
+        .iter()
+        .filter(|op| op.is_arch_v3())
+        .map(|op| {
+            let code = op.code;
+            let variant = &op.variant;
+            quote! { #code => Ok(#enum_name::#variant) }
+        })
+        .collect();
+
+    let group_arms: Vec<_> = def
+        .opcodes
+        .iter()
+        .map(|op| {
+            let variant = &op.variant;
+            let group = &op.group;
+            quote! { #enum_name::#variant => #group }
+        })
+        .collect();
+
+    let all_variants: Vec<_> = def.opcodes.iter().map(|op| &op.variant).collect();
+
+    quote! {
+        impl ::sbpf_common_tablegen::OpcodeTable for #enum_name {
+            type Group = #group_ty;
+
+            fn to_str(&self) -> &'static str {
+                match self {
+                    #(#to_str_arms,)*
+                }
+            }
+
+            fn group(self) -> Self::Group {
+                match self {
+                    #(#group_arms,)*
+                }
+            }
+
+            /// Decode opcode byte with sBPF v3 semantics.
+            fn try_from_sbpf_v3(
+                opcode: u8,
+            ) -> ::core::result::Result<Self, ::sbpf_common_tablegen::OpcodeError> {
+                match opcode {
+
+                    #(#v3_arms,)*
+                    _ => ::core::convert::TryInto::try_into(opcode),
+                }
+            }
+
+            fn all() -> &'static [Self] {
+                &[#(#enum_name::#all_variants),*]
+            }
+        }
+    }
+}
+
+fn group_enum_path(path: &Path) -> Path {
+    let mut ty = path.clone();
+    if ty.segments.len() > 1 {
+        ty.segments.pop();
+        let segs = ty.segments.into_iter().collect::<Vec<_>>();
+        ty.segments = segs.into_iter().collect();
+    }
+    ty
+}
+
+/// Expand `#[derive(OpcodeGroup)]` into `HandlerTypes` and `OpcodeGroup` trait impls.
+pub fn expand_opcode_group(def: &OpcodeGroupDef) -> TokenStream {
+    let enum_name = &def.enum_name;
+    let decode_type = &def.handlers.decode;
+    let validate_type = &def.handlers.validate;
+    let execute_type = &def.handlers.execute;
+
+    let title_arms: Vec<_> = def
+        .groups
+        .iter()
+        .map(|g| {
+            let v = &g.variant;
+            let title = &g.title;
+            quote! { #enum_name::#v => #title }
+        })
+        .collect();
+
+    let desc_arms: Vec<_> = def
+        .groups
+        .iter()
+        .map(|g| {
+            let v = &g.variant;
+            let desc = &g.description;
+            quote! { #enum_name::#v => #desc }
+        })
+        .collect();
+
+    let decode_arms: Vec<_> = def
+        .groups
+        .iter()
+        .map(|g| {
+            let v = &g.variant;
+            let path = &g.decode;
+            quote! { #enum_name::#v => #path }
+        })
+        .collect();
+
+    let validate_arms: Vec<_> = def
+        .groups
+        .iter()
+        .map(|g| {
+            let v = &g.variant;
+            let path = &g.validate;
+            quote! { #enum_name::#v => #path }
+        })
+        .collect();
+
+    let execute_arms: Vec<_> = def
+        .groups
+        .iter()
+        .map(|g| {
+            let v = &g.variant;
+            let path = &g.execute;
+            quote! { #enum_name::#v => #path }
+        })
+        .collect();
+
+    let all_variants: Vec<_> = def.groups.iter().map(|g| &g.variant).collect();
+
+    quote! {
+        impl ::sbpf_common_tablegen::HandlerTypes for #enum_name {
+            type DecodeFn = #decode_type;
+            type ValidateFn = #validate_type;
+            type ExecuteFn = #execute_type;
+        }
+
+        impl ::sbpf_common_tablegen::OpcodeGroup for #enum_name {
+            fn title(self) -> &'static str {
+                match self {
+                    #(#title_arms,)*
+                }
+            }
+
+            fn description(self) -> &'static str {
+                match self {
+                    #(#desc_arms,)*
+                }
+            }
+
+            fn decode_fn(self) -> Self::DecodeFn {
+                match self {
+                    #(#decode_arms,)*
+                }
+            }
+
+            fn validate_fn(self) -> Self::ValidateFn {
+                match self {
+                    #(#validate_arms,)*
+                }
+            }
+
+            fn execute_fn(self) -> Self::ExecuteFn {
+                match self {
+                    #(#execute_arms,)*
+                }
+            }
+
+            fn all() -> &'static [Self] {
+                &[#(#enum_name::#all_variants),*]
+            }
+        }
+    }
+}

--- a/crates/common/macros/tablegen/src/ir.rs
+++ b/crates/common/macros/tablegen/src/ir.rs
@@ -1,0 +1,140 @@
+use {
+    proc_macro2::Span,
+    std::collections::BTreeMap,
+    syn::{Ident, Path},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OpcodeArch {
+    V2,
+    V3,
+}
+
+impl OpcodeArch {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OpcodeArch::V2 => "v2",
+            OpcodeArch::V3 => "v3",
+        }
+    }
+}
+
+/// An opcode variant after parsing `#[opcode(...)]`.
+#[derive(Debug, Clone)]
+pub struct OpcodeDef {
+    pub variant: Ident,
+    pub mnemonic: String,
+    pub code: u8,
+    /// The group the opcode belongs to
+    pub group: Path,
+    pub doc: String,
+    pub operator: Option<String>,
+    /// If the opcode is only available in a specific arch (v2 or v3)
+    pub arch: Option<OpcodeArch>,
+    pub span: Span,
+}
+
+impl OpcodeDef {
+    pub fn group_variant_name(&self) -> Option<String> {
+        self.group.segments.last().map(|s| s.ident.to_string())
+    }
+
+    pub fn variant_name(&self) -> String {
+        self.variant.to_string()
+    }
+
+    pub fn is_arch_v3(&self) -> bool {
+        self.arch == Some(OpcodeArch::V3)
+    }
+
+    /// Check if this variant is the FromStr target for its mnemonic.
+    pub fn is_from_str_target(&self, all: &[OpcodeDef]) -> bool {
+        let variants: Vec<_> = all.iter().filter(|o| o.mnemonic == self.mnemonic).collect();
+        // If the mnemonic has a single variant, then it is the target.
+        if variants.len() <= 1 {
+            return true;
+        }
+        // If the mnemonic has more than one variants, then prefer the Imm variant as the target.
+        // For example - add64 is the mnemonic for both Add64Imm and Add64Reg variants.
+        let imm = variants.iter().find(|o| o.variant_name().ends_with("Imm"));
+        match imm {
+            Some(target) => target.variant_name() == self.variant_name(),
+            None => {
+                // If there's no Imm variant, then the first variant in the list is the target.
+                variants
+                    .first()
+                    .map(|o| o.variant_name() == self.variant_name())
+                    .unwrap_or(true)
+            }
+        }
+    }
+}
+
+/// A group variant after parsing `#[group(...)]`.
+#[derive(Debug, Clone)]
+pub struct GroupDef {
+    pub variant: Ident,
+    pub title: String,
+    pub description: String,
+    pub decode: Path,
+    pub validate: Path,
+    pub execute: Path,
+    pub span: Span,
+}
+
+/// Handler function type paths after parsing `#[handlers(...)]`.
+#[derive(Debug, Clone)]
+pub struct HandlerTypePaths {
+    pub decode: Path,
+    pub validate: Path,
+    pub execute: Path,
+    pub span: Span,
+}
+
+impl GroupDef {
+    pub fn variant_name(&self) -> String {
+        self.variant.to_string()
+    }
+}
+
+/// Full opcode table.
+#[derive(Debug, Clone)]
+pub struct OpcodeTableDef {
+    pub enum_name: Ident,
+    pub opcodes: Vec<OpcodeDef>,
+}
+
+impl OpcodeTableDef {
+    /// Get opcodes by group variant.
+    pub fn opcodes_in_group(&self, group_variant: &str) -> Vec<&OpcodeDef> {
+        self.opcodes
+            .iter()
+            .filter(|o| o.group_variant_name().as_deref() == Some(group_variant))
+            .collect()
+    }
+
+    /// Get a mapping of all group variants and their opcodes.
+    pub fn opcodes_by_group(&self) -> BTreeMap<String, Vec<&OpcodeDef>> {
+        let mut map: BTreeMap<String, Vec<&OpcodeDef>> = BTreeMap::new();
+        for op in &self.opcodes {
+            if let Some(g) = op.group_variant_name() {
+                map.entry(g).or_default().push(op);
+            }
+        }
+        map
+    }
+}
+
+/// Full opcode group.
+#[derive(Debug, Clone)]
+pub struct OpcodeGroupDef {
+    pub enum_name: Ident,
+    pub handlers: HandlerTypePaths,
+    pub groups: Vec<GroupDef>,
+}
+
+impl OpcodeGroupDef {
+    pub fn get(&self, variant: &str) -> Option<&GroupDef> {
+        self.groups.iter().find(|g| g.variant_name() == variant)
+    }
+}

--- a/crates/common/macros/tablegen/src/lib.rs
+++ b/crates/common/macros/tablegen/src/lib.rs
@@ -1,0 +1,73 @@
+pub mod error;
+pub mod expand;
+pub mod ir;
+pub mod parse;
+pub mod validate;
+
+pub use {
+    expand::{expand_opcode_group, expand_opcode_table},
+    ir::{GroupDef, HandlerTypePaths, OpcodeArch, OpcodeDef, OpcodeGroupDef, OpcodeTableDef},
+    parse::{parse_opcode_group, parse_opcode_table},
+    validate::{validate_opcode_group, validate_opcode_table},
+};
+
+/// Trait for OpcodeTable metadata, group membership, and byte conversions.
+pub trait OpcodeTable: Copy + Sized + 'static {
+    type Group: OpcodeGroup;
+
+    fn to_str(&self) -> &'static str;
+    fn group(self) -> Self::Group;
+    fn try_from_sbpf_v3(opcode: u8) -> Result<Self, OpcodeError>;
+    fn all() -> &'static [Self];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OpcodeError {
+    InvalidOpcode { byte: u8 },
+}
+
+impl core::fmt::Display for OpcodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OpcodeError::InvalidOpcode { byte } => {
+                write!(f, "invalid opcode: 0x{byte:02x}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OpcodeError {}
+
+/// Trait for OpcodeGroup metadata and decode/validate/execute handler routing.
+pub trait OpcodeGroup: HandlerTypes + Copy + Sized + 'static {
+    fn title(self) -> &'static str;
+    fn description(self) -> &'static str;
+    fn decode_fn(self) -> Self::DecodeFn;
+    fn validate_fn(self) -> Self::ValidateFn;
+    fn execute_fn(self) -> Self::ExecuteFn;
+    fn all() -> &'static [Self];
+}
+
+/// Handler types for an `OpcodeGroup`.
+pub trait HandlerTypes {
+    type DecodeFn: Copy;
+    type ValidateFn: Copy;
+    type ExecuteFn: Copy;
+}
+
+/// Parse, validate and expand an `OpcodeTable`.
+pub fn derive_opcode_table(input: &syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let table = parse_opcode_table(input)?;
+    validate_opcode_table(&table)?;
+    Ok(expand_opcode_table(&table))
+}
+
+/// Parse, validate and expand an `OpcodeGroup`.
+pub fn derive_opcode_group(input: &syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let table = parse_opcode_group(input)?;
+    validate_opcode_group(&table)?;
+    Ok(expand_opcode_group(&table))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/common/macros/tablegen/src/parse.rs
+++ b/crates/common/macros/tablegen/src/parse.rs
@@ -1,0 +1,300 @@
+use {
+    crate::{
+        error::err,
+        ir::{GroupDef, HandlerTypePaths, OpcodeArch, OpcodeDef, OpcodeGroupDef, OpcodeTableDef},
+    },
+    syn::{Attribute, Data, DeriveInput, Expr, Fields, Lit, Path, Variant, spanned::Spanned},
+};
+
+/// Parse an enum with `#[opcode(...)]` on each variant.
+pub fn parse_opcode_table(input: &DeriveInput) -> syn::Result<OpcodeTableDef> {
+    let enum_name = input.ident.clone();
+    let data = match &input.data {
+        Data::Enum(data) => data,
+        _ => {
+            return Err(err(
+                enum_name.span(),
+                "OpcodeTable can only be derived for enums",
+            ));
+        }
+    };
+
+    let mut opcodes = Vec::new();
+    for variant in &data.variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(err(
+                variant.ident.span(),
+                "OpcodeTable variants must be unit variants",
+            ));
+        }
+        let attr = find_attr(&variant.attrs, "opcode")?.ok_or_else(|| {
+            err(
+                variant.ident.span(),
+                format!("variant `{}` is missing #[opcode(...)]", variant.ident),
+            )
+        })?;
+        opcodes.push(parse_opcode_attr(variant, attr)?);
+    }
+
+    Ok(OpcodeTableDef { enum_name, opcodes })
+}
+
+/// Parse an enum with `#[group(...)]` on each variant.
+pub fn parse_opcode_group(input: &DeriveInput) -> syn::Result<OpcodeGroupDef> {
+    let enum_name = input.ident.clone();
+    let data = match &input.data {
+        Data::Enum(data) => data,
+        _ => {
+            return Err(err(
+                enum_name.span(),
+                "OpcodeGroup can only be derived for enums",
+            ));
+        }
+    };
+
+    let handlers_attr = find_attr(&input.attrs, "handlers")?
+        .ok_or_else(|| err(enum_name.span(), "OpcodeGroup requires #[handlers(...)]"))?;
+    let handlers = parse_handlers_attr(handlers_attr)?;
+
+    let mut groups = Vec::new();
+    for variant in &data.variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(err(
+                variant.ident.span(),
+                "OpcodeGroup variants must be unit variants",
+            ));
+        }
+        let attr = find_attr(&variant.attrs, "group")?.ok_or_else(|| {
+            err(
+                variant.ident.span(),
+                format!("variant `{}` is missing #[group(...)]", variant.ident),
+            )
+        })?;
+        groups.push(parse_group_attr(variant, attr)?);
+    }
+
+    Ok(OpcodeGroupDef {
+        enum_name,
+        handlers,
+        groups,
+    })
+}
+
+fn find_attr<'a>(attrs: &'a [Attribute], name: &str) -> syn::Result<Option<&'a Attribute>> {
+    let mut matches = attrs.iter().filter(|attr| attr.path().is_ident(name));
+    let attr = matches.next();
+    if let Some(duplicate) = matches.next() {
+        return Err(err(
+            duplicate.path().span(),
+            format!("#[{name}(...)] specified more than once"),
+        ));
+    }
+    Ok(attr)
+}
+
+fn parse_opcode_attr(variant: &Variant, attr: &Attribute) -> syn::Result<OpcodeDef> {
+    let mut mnemonic: Option<String> = None;
+    let mut code: Option<u8> = None;
+    let mut group: Option<Path> = None;
+    let mut doc: Option<String> = None;
+    let mut operator: Option<String> = None;
+    let mut arch: Option<OpcodeArch> = None;
+
+    attr.parse_nested_meta(|meta| {
+        let key = meta
+            .path
+            .get_ident()
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+
+        match key.as_str() {
+            "mnemonic" => {
+                parse_once(&mut mnemonic, &meta, "mnemonic", parse_string_value)?;
+            }
+            "code" => {
+                parse_once(&mut code, &meta, "code", parse_u8_value)?;
+            }
+            "group" => {
+                parse_once(&mut group, &meta, "group", parse_path_value)?;
+            }
+            "doc" => {
+                parse_once(&mut doc, &meta, "doc", parse_string_value)?;
+            }
+            "operator" => {
+                parse_once(&mut operator, &meta, "operator", parse_string_value)?;
+            }
+            "arch" => {
+                parse_once(&mut arch, &meta, "arch", parse_arch_value)?;
+            }
+            other => {
+                return Err(meta.error(format!("unknown opcode field `{other}`")));
+            }
+        }
+        Ok(())
+    })?;
+
+    let span = variant.ident.span();
+    let mnemonic = mnemonic.ok_or_else(|| err(span, "missing required field `mnemonic`"))?;
+    let code = code.ok_or_else(|| err(span, "missing required field `code`"))?;
+    let group = group.ok_or_else(|| err(span, "missing required field `group`"))?;
+    let doc = doc.ok_or_else(|| err(span, "missing required field `doc`"))?;
+
+    Ok(OpcodeDef {
+        variant: variant.ident.clone(),
+        mnemonic,
+        code,
+        group,
+        doc,
+        operator,
+        arch,
+        span,
+    })
+}
+
+fn parse_group_attr(variant: &Variant, attr: &Attribute) -> syn::Result<GroupDef> {
+    let mut title: Option<String> = None;
+    let mut description: Option<String> = None;
+    let mut decode: Option<Path> = None;
+    let mut validate: Option<Path> = None;
+    let mut execute: Option<Path> = None;
+
+    attr.parse_nested_meta(|meta| {
+        let key = meta
+            .path
+            .get_ident()
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+
+        match key.as_str() {
+            "title" => parse_once(&mut title, &meta, "title", parse_string_value)?,
+            "description" => {
+                parse_once(&mut description, &meta, "description", parse_string_value)?;
+            }
+            "decode" => parse_once(&mut decode, &meta, "decode", parse_path_value)?,
+            "validate" => parse_once(&mut validate, &meta, "validate", parse_path_value)?,
+            "execute" => parse_once(&mut execute, &meta, "execute", parse_path_value)?,
+            other => {
+                return Err(meta.error(format!("unknown group field `{other}`")));
+            }
+        }
+        Ok(())
+    })?;
+
+    let span = variant.ident.span();
+    let title = title.ok_or_else(|| err(span, "missing required field `title`"))?;
+    let description =
+        description.ok_or_else(|| err(span, "missing required field `description`"))?;
+    let decode = decode.ok_or_else(|| err(span, "missing required field `decode`"))?;
+    let validate = validate.ok_or_else(|| err(span, "missing required field `validate`"))?;
+    let execute = execute.ok_or_else(|| err(span, "missing required field `execute`"))?;
+
+    Ok(GroupDef {
+        variant: variant.ident.clone(),
+        title,
+        description,
+        decode,
+        validate,
+        execute,
+        span,
+    })
+}
+
+fn parse_handlers_attr(attr: &Attribute) -> syn::Result<HandlerTypePaths> {
+    let mut decode: Option<Path> = None;
+    let mut validate: Option<Path> = None;
+    let mut execute: Option<Path> = None;
+
+    attr.parse_nested_meta(|meta| {
+        let key = meta
+            .path
+            .get_ident()
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+
+        match key.as_str() {
+            "decode" => parse_once(&mut decode, &meta, "decode", parse_path_value)?,
+            "validate" => parse_once(&mut validate, &meta, "validate", parse_path_value)?,
+            "execute" => parse_once(&mut execute, &meta, "execute", parse_path_value)?,
+            other => {
+                return Err(meta.error(format!("unknown handler type field `{other}`")));
+            }
+        }
+        Ok(())
+    })?;
+
+    let span = attr.path().span();
+    let decode = decode.ok_or_else(|| err(span, "missing required handler type `decode`"))?;
+    let validate = validate.ok_or_else(|| err(span, "missing required handler type `validate`"))?;
+    let execute = execute.ok_or_else(|| err(span, "missing required handler type `execute`"))?;
+
+    Ok(HandlerTypePaths {
+        decode,
+        validate,
+        execute,
+        span,
+    })
+}
+
+fn parse_once<T>(
+    slot: &mut Option<T>,
+    meta: &syn::meta::ParseNestedMeta<'_>,
+    field: &str,
+    parse: impl FnOnce(&syn::meta::ParseNestedMeta<'_>) -> syn::Result<T>,
+) -> syn::Result<()> {
+    if slot.is_some() {
+        return Err(meta.error(format!("`{field}` specified more than once")));
+    }
+    *slot = Some(parse(meta)?);
+    Ok(())
+}
+
+fn parse_string_value(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<String> {
+    let value = meta.value()?;
+    let lit: Lit = value.parse()?;
+    match lit {
+        Lit::Str(s) => Ok(s.value()),
+        _ => Err(meta.error("expected string literal")),
+    }
+}
+
+fn parse_u8_value(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<u8> {
+    let value = meta.value()?;
+    let expr: Expr = value.parse()?;
+    match &expr {
+        Expr::Lit(syn::ExprLit {
+            lit: Lit::Int(i), ..
+        }) => {
+            let n: u64 = i.base10_parse()?;
+            if n > u8::MAX as u64 {
+                return Err(meta.error("opcode code must fit in u8"));
+            }
+            Ok(n as u8)
+        }
+        _ => Err(meta.error("expected integer literal for `code`")),
+    }
+}
+
+fn parse_path_value(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<Path> {
+    let value = meta.value()?;
+    let expr: Expr = value.parse()?;
+    match expr {
+        Expr::Path(p) => Ok(p.path),
+        _ => Err(meta.error("expected path")),
+    }
+}
+
+fn parse_arch_value(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<OpcodeArch> {
+    let value = meta.value()?;
+    let expr: Expr = value.parse()?;
+    let name = match &expr {
+        Expr::Path(p) if p.path.segments.len() == 1 => p.path.segments[0].ident.to_string(),
+        _ => {
+            return Err(meta.error("expected `arch = v2` or `arch = v3`"));
+        }
+    };
+    match name.to_ascii_lowercase().as_str() {
+        "v2" => Ok(OpcodeArch::V2),
+        "v3" => Ok(OpcodeArch::V3),
+        _ => Err(meta.error(format!("unknown arch `{name}`; expected v2 or v3"))),
+    }
+}

--- a/crates/common/macros/tablegen/src/tests.rs
+++ b/crates/common/macros/tablegen/src/tests.rs
@@ -1,0 +1,476 @@
+#[cfg(test)]
+mod tests {
+    use {
+        crate::{
+            expand::{expand_opcode_group, expand_opcode_table},
+            parse::{parse_opcode_group, parse_opcode_table},
+            validate::{validate_opcode_group, validate_opcode_table},
+        },
+        syn::{DeriveInput, parse_quote},
+    };
+
+    fn test_opcode_table_input() -> DeriveInput {
+        parse_quote! {
+            pub enum O {
+                #[opcode(
+                    mnemonic = "op1",
+                    code = 0x01,
+                    group = G::A,
+                    doc = "op1 imm",
+                    operator = "+=",
+                )]
+                Op1Imm,
+
+                #[opcode(
+                    mnemonic = "op1",
+                    code = 0x02,
+                    group = G::B,
+                    doc = "op1 reg",
+                    operator = "+=",
+                )]
+                Op1Reg,
+
+                #[opcode(
+                    mnemonic = "op2",
+                    code = 0x03,
+                    group = G::C,
+                    doc = "op2",
+                    arch = v3,
+                )]
+                Op2,
+
+                #[opcode(
+                    mnemonic = "op3",
+                    code = 0x04,
+                    group = G::D,
+                    doc = "op3",
+                )]
+                Op3,
+            }
+        }
+    }
+
+    fn test_opcode_group_input() -> DeriveInput {
+        parse_quote! {
+            #[handlers(
+                decode = DecodeFn,
+                validate = ValidateFn,
+                execute = ExecuteFn,
+            )]
+            pub enum G {
+                #[group(
+                    title = "A",
+                    description = "Group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                A,
+
+                #[group(
+                    title = "B",
+                    description = "Group B",
+                    decode = dec_b,
+                    validate = val_b,
+                    execute = exe_b,
+                )]
+                B,
+
+                #[group(
+                    title = "C",
+                    description = "Group C",
+                    decode = dec_c,
+                    validate = val_c,
+                    execute = exe_c,
+                )]
+                C,
+
+                #[group(
+                    title = "D",
+                    description = "Group D",
+                    decode = dec_d,
+                    validate = val_d,
+                    execute = exe_d,
+                )]
+                D,
+            }
+        }
+    }
+
+    // Parse tests
+
+    #[test]
+    fn parse_opcode_table_fields() {
+        let opcode_table_def = parse_opcode_table(&test_opcode_table_input()).unwrap();
+        assert_eq!(opcode_table_def.enum_name, "O");
+        assert_eq!(opcode_table_def.opcodes.len(), 4);
+
+        let op1_imm = &opcode_table_def.opcodes[0];
+        assert_eq!(op1_imm.variant_name(), "Op1Imm");
+        assert_eq!(op1_imm.mnemonic, "op1");
+        assert_eq!(op1_imm.code, 0x01);
+        assert_eq!(op1_imm.operator.as_deref(), Some("+="));
+        assert!(op1_imm.arch.is_none());
+        assert!(!op1_imm.is_arch_v3());
+        assert_eq!(op1_imm.group_variant_name().as_deref(), Some("A"));
+
+        let op2 = opcode_table_def
+            .opcodes
+            .iter()
+            .find(|o| o.variant_name() == "Op2")
+            .unwrap();
+        assert!(op2.is_arch_v3());
+        assert_eq!(op2.code, 0x03);
+    }
+
+    #[test]
+    fn parse_opcode_group_fields() {
+        let opcode_group_def = parse_opcode_group(&test_opcode_group_input()).unwrap();
+        assert_eq!(opcode_group_def.groups.len(), 4);
+        assert_eq!(opcode_group_def.groups[0].title, "A");
+        assert_eq!(
+            opcode_group_def
+                .handlers
+                .decode
+                .segments
+                .last()
+                .unwrap()
+                .ident,
+            "DecodeFn"
+        );
+        assert_eq!(
+            opcode_group_def.groups[0]
+                .decode
+                .segments
+                .last()
+                .unwrap()
+                .ident
+                .to_string(),
+            "dec_a"
+        );
+    }
+
+    #[test]
+    fn missing_group_handler_path_errors() {
+        let input: DeriveInput = parse_quote! {
+            #[handlers(
+                decode = DecodeFn,
+                validate = ValidateFn,
+                execute = ExecuteFn,
+            )]
+            pub enum G {
+                #[group(title = "A", description = "Group A")]
+                A,
+            }
+        };
+        let err = parse_opcode_group(&input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("decode") || msg.contains("validate") || msg.contains("execute"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_handlers_errors() {
+        let input: DeriveInput = parse_quote! {
+            pub enum G {
+                #[group(
+                    title = "A",
+                    description = "Group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                A,
+            }
+        };
+        let err = parse_opcode_group(&input).unwrap_err();
+        assert!(
+            err.to_string().contains("handlers"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_opcode_attr_errors() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                Bare,
+            }
+        };
+        let err = parse_opcode_table(&input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("missing") && msg.contains("opcode"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_required_field_errors() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                #[opcode(mnemonic = "x", code = 0x01, group = G::A)]
+                X,
+            }
+        };
+        let err = parse_opcode_table(&input).unwrap_err();
+        assert!(
+            err.to_string().contains("doc"),
+            "expected missing doc error, got {}",
+            err
+        );
+    }
+
+    #[test]
+    fn duplicate_opcode_field_errors() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                #[opcode(
+                    mnemonic = "x",
+                    code = 0x01,
+                    code = 0x02,
+                    group = G::A,
+                    doc = "x",
+                )]
+                X,
+            }
+        };
+        let err = parse_opcode_table(&input).unwrap_err();
+        assert_eq!(err.to_string(), "`code` specified more than once");
+    }
+
+    #[test]
+    fn duplicate_group_field_errors() {
+        let input: DeriveInput = parse_quote! {
+            #[handlers(decode = DecodeFn, validate = ValidateFn, execute = ExecuteFn)]
+            pub enum G {
+                #[group(
+                    title = "A",
+                    title = "Duplicate A",
+                    description = "Group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                A,
+            }
+        };
+        let err = parse_opcode_group(&input).unwrap_err();
+        assert_eq!(err.to_string(), "`title` specified more than once");
+    }
+
+    #[test]
+    fn duplicate_handlers_field_errors() {
+        let input: DeriveInput = parse_quote! {
+            #[handlers(
+                decode = DecodeFn,
+                decode = DecodeFn2,
+                validate = ValidateFn,
+                execute = ExecuteFn,
+            )]
+            pub enum G {
+                #[group(
+                    title = "A",
+                    description = "Group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                A,
+            }
+        };
+        let err = parse_opcode_group(&input).unwrap_err();
+        assert_eq!(err.to_string(), "`decode` specified more than once");
+    }
+
+    #[test]
+    fn duplicate_opcode_attrs_error() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                #[opcode(mnemonic = "x", code = 0x01, group = G::A, doc = "x")]
+                #[opcode(mnemonic = "y", code = 0x02, group = G::A, doc = "y")]
+                X,
+            }
+        };
+        let err = parse_opcode_table(&input).unwrap_err();
+        assert_eq!(err.to_string(), "#[opcode(...)] specified more than once");
+    }
+
+    #[test]
+    fn duplicate_group_attrs_error() {
+        let input: DeriveInput = parse_quote! {
+            #[handlers(decode = DecodeFn, validate = ValidateFn, execute = ExecuteFn)]
+            pub enum G {
+                #[group(
+                    title = "A",
+                    description = "Group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                #[group(
+                    title = "Duplicate A",
+                    description = "Duplicate group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                A,
+            }
+        };
+        let err = parse_opcode_group(&input).unwrap_err();
+        assert_eq!(err.to_string(), "#[group(...)] specified more than once");
+    }
+
+    #[test]
+    fn duplicate_handlers_attrs_error() {
+        let input: DeriveInput = parse_quote! {
+            #[handlers(decode = DecodeFn, validate = ValidateFn, execute = ExecuteFn)]
+            #[handlers(decode = DecodeFn, validate = ValidateFn, execute = ExecuteFn)]
+            pub enum G {
+                #[group(
+                    title = "A",
+                    description = "Group A",
+                    decode = dec_a,
+                    validate = val_a,
+                    execute = exe_a,
+                )]
+                A,
+            }
+        };
+        let err = parse_opcode_group(&input).unwrap_err();
+        assert_eq!(err.to_string(), "#[handlers(...)] specified more than once");
+    }
+
+    // Validate tests.
+
+    #[test]
+    fn validate_opcode_table_ok() {
+        let opcode_table_def = parse_opcode_table(&test_opcode_table_input()).unwrap();
+        validate_opcode_table(&opcode_table_def).unwrap();
+    }
+
+    #[test]
+    fn validate_opcode_group_ok() {
+        let opcode_group_def = parse_opcode_group(&test_opcode_group_input()).unwrap();
+        validate_opcode_group(&opcode_group_def).unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_non_v3_code() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                #[opcode(mnemonic = "a", code = 0x01, group = G::A, doc = "a")]
+                A,
+                #[opcode(mnemonic = "b", code = 0x01, group = G::B, doc = "b")]
+                B,
+            }
+        };
+        let opcode_table_def = parse_opcode_table(&input).unwrap();
+        let err = validate_opcode_table(&opcode_table_def).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate non-v3") || msg.contains("0x01"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_v3_code() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                #[opcode(mnemonic = "a", code = 0x01, group = G::A, doc = "a", arch = v3)]
+                A,
+                #[opcode(mnemonic = "b", code = 0x01, group = G::B, doc = "b", arch = v3)]
+                B,
+            }
+        };
+        let opcode_table_def = parse_opcode_table(&input).unwrap();
+        let err = validate_opcode_table(&opcode_table_def).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate v3") || msg.contains("0x01"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_opcode_table() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {}
+        };
+        let opcode_table_def = parse_opcode_table(&input).unwrap();
+        let err = validate_opcode_table(&opcode_table_def).unwrap_err();
+        assert!(
+            err.to_string().contains("at least one opcode variant"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_opcode_group() {
+        let input: DeriveInput = parse_quote! {
+            #[handlers(decode = DecodeFn, validate = ValidateFn, execute = ExecuteFn)]
+            pub enum Group {}
+        };
+        let opcode_group_def = parse_opcode_group(&input).unwrap();
+        let err = validate_opcode_group(&opcode_group_def).unwrap_err();
+        assert!(
+            err.to_string().contains("at least one group variant"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_allows_v3_and_non_v3_same_code() {
+        let input: DeriveInput = parse_quote! {
+            pub enum Opcode {
+                #[opcode(mnemonic = "x", code = 0x01, group = G::A, doc = "non-v3")]
+                X,
+                #[opcode(
+                    mnemonic = "y",
+                    code = 0x01,
+                    group = G::B,
+                    doc = "v3-only",
+                    arch = v3,
+                )]
+                Y,
+            }
+        };
+        let opcode_table_def = parse_opcode_table(&input).unwrap();
+        validate_opcode_table(&opcode_table_def).unwrap();
+    }
+
+    // Expand tests.
+
+    #[test]
+    fn expand_opcode_table_core_impls() {
+        let opcode_table_def = parse_opcode_table(&test_opcode_table_input()).unwrap();
+        validate_opcode_table(&opcode_table_def).unwrap();
+        let s = expand_opcode_table(&opcode_table_def).to_string();
+
+        assert!(s.contains("OpcodeTable for O"));
+        assert!(s.contains("type Group = G"));
+        assert!(s.contains("fn to_str"));
+        assert!(s.contains("fn group"));
+        assert!(s.contains("fn try_from_sbpf_v3"));
+        assert!(s.contains("fn all"));
+    }
+
+    #[test]
+    fn expand_opcode_group_core_impls() {
+        let opcode_group_def = parse_opcode_group(&test_opcode_group_input()).unwrap();
+        let s = expand_opcode_group(&opcode_group_def).to_string();
+
+        assert!(s.contains("HandlerTypes for G"));
+        assert!(s.contains("OpcodeGroup for G"));
+        assert!(s.contains("fn title"));
+        assert!(s.contains("fn description"));
+        assert!(s.contains("fn decode_fn"));
+        assert!(s.contains("fn validate_fn"));
+        assert!(s.contains("fn execute_fn"));
+        assert!(s.contains("fn all"));
+    }
+}

--- a/crates/common/macros/tablegen/src/validate.rs
+++ b/crates/common/macros/tablegen/src/validate.rs
@@ -1,0 +1,87 @@
+use {
+    crate::{
+        error::{combine_errors, err},
+        ir::{OpcodeGroupDef, OpcodeTableDef},
+    },
+    std::collections::{HashMap, HashSet},
+    syn::Error,
+};
+
+/// Validate an opcode table.
+pub fn validate_opcode_table(def: &OpcodeTableDef) -> Result<(), Error> {
+    let mut errors = Vec::new();
+
+    if def.opcodes.is_empty() {
+        errors.push(err(
+            def.enum_name.span(),
+            "OpcodeTable requires at least one opcode variant",
+        ));
+    }
+
+    // v3 can have overlapping codes with non-v3 so when checking for
+    // duplicates codes, check v3 and non-v3 separately.
+    let mut v3_codes: HashMap<u8, String> = HashMap::new();
+    let mut non_v3_codes: HashMap<u8, String> = HashMap::new();
+
+    for op in &def.opcodes {
+        let name = op.variant_name();
+        if op.is_arch_v3() {
+            if let Some(prev) = v3_codes.insert(op.code, name.clone()) {
+                errors.push(err(
+                    op.span,
+                    format!(
+                        "duplicate code found for v3 opcodes `{prev}` and `{name}`: 0x{:02x} ",
+                        op.code
+                    ),
+                ));
+            }
+        } else if let Some(prev) = non_v3_codes.insert(op.code, name.clone()) {
+            errors.push(err(
+                op.span,
+                format!(
+                    "duplicate code found for opcodes `{prev}` and `{name}`: 0x{:02x} ",
+                    op.code
+                ),
+            ));
+        }
+    }
+
+    for op in &def.opcodes {
+        if op.mnemonic.is_empty() {
+            errors.push(err(op.span, "mnemonic must not be empty"));
+        }
+        if op.doc.is_empty() {
+            errors.push(err(op.span, "doc must not be empty"));
+        }
+    }
+
+    combine_errors(errors)
+}
+
+/// Validate an opcode group.
+pub fn validate_opcode_group(def: &OpcodeGroupDef) -> Result<(), Error> {
+    let mut errors = Vec::new();
+    let mut seen = HashSet::new();
+
+    if def.groups.is_empty() {
+        errors.push(err(
+            def.enum_name.span(),
+            "OpcodeGroup requires at least one group variant",
+        ));
+    }
+
+    for g in &def.groups {
+        let name = g.variant_name();
+        if !seen.insert(name.clone()) {
+            errors.push(err(g.span, format!("duplicate group variant `{name}`")));
+        }
+        if g.title.is_empty() {
+            errors.push(err(g.span, "title must not be empty"));
+        }
+        if g.description.is_empty() {
+            errors.push(err(g.span, "description must not be empty"));
+        }
+    }
+
+    combine_errors(errors)
+}


### PR DESCRIPTION
### Summary

Add a macro-based tablegen system for opcodes via two crates:

- `tablegen`: core parsing, IR, validation, and expansion library
- `derive`: thin proc-macro wrappers

The two macros are:

- `#[derive(OpcodeTable)]`:  generates implementations for traits like `FromStr`, `Display`, `TryFrom`, `From`, and others. For example - this will automatically handle conversions between opcode <> enum <> string.
- `#[derive(OpcodeGroup)]`: organizes opcodes into groups and wires up handlers (decode/execute/validate)

There are `trybuild` tests inside the `derive` crate [here](https://github.com/bidhan-a/sbpf-cli/tree/feat/sbpf-tablegen/crates/common/macros/derive/tests), which demonstrate how the macros are used.

[Note that this PR only contains the tablegen implementation to keep the changes from getting too huge (it's already a bit big but a lot of the LOC comes from the tests). It has not been integrated yet so it doesn't affect any existing functionality.]

In a follow-up PR, we'll:

- Integrate tablegen with `sbpf-common` by applying the macros to existing `Opcode` enum and delete all the handwritten code. Plus make sure there are no regressions.
- Add a bytecode documentation generator. It will use the same `tablegen` crate to parse the macro input, but instead of expanding it into rust code, it will transform it into nicely formatted Markdown documentation (the macros will provide all the details like title, description, doc, etc. needed for this).