### PR TITLE
fix: handle rodata relocations

### DIFF
--- a/crates/analyzer/src/remove_dead_functions.rs
+++ b/crates/analyzer/src/remove_dead_functions.rs
@@ -1,4 +1,5 @@
 use {
+    sbpf_common::opcode::Opcode,
     sbpf_ir::{
         BlockId, Cfg, CfgFunction, FunctionId,
         graph_engine::{WorklistEngine, WorklistVisitor},
@@ -15,8 +16,8 @@ pub struct RemovedFunction {
     pub node_ids: Vec<usize>,
 }
 
-/// Removes functions not reachable from `functions()[0]` via `call imm` edges and returns
-/// their names and byte ranges. Dead functions' blocks and instructions are dropped automatically
+/// Removes functions not reachable from `functions()[0]` via `call imm` edges and not referenced by lddw/rodata,
+/// and returns their names and byte ranges. Dead functions' blocks and instructions are dropped automatically
 /// via Rust ownership. Successor/predecessor relationships between live blocks are
 /// unchanged and are NOT rebuilt.
 pub fn remove_dead_functions(cfg: &mut Cfg) -> Vec<RemovedFunction> {
@@ -89,13 +90,46 @@ fn reachable_functions(cfg: &Cfg) -> HashSet<FunctionId> {
         }
     }
 
+    let mut enqueued_funcs = HashSet::from([entry_fi]);
+    let mut initial_blocks = cfg.functions()[entry_fi].block_ids().to_vec();
+
+    // Include functions that are referenced by rodata.
+    for fi in cfg
+        .rodata()
+        .iter()
+        .flat_map(|data| data.referenced_blocks.iter().copied())
+        .filter_map(|block_id| cfg.function_of_block(block_id))
+    {
+        if enqueued_funcs.insert(fi) {
+            initial_blocks.extend_from_slice(cfg.functions()[fi].block_ids());
+        }
+    }
+
+    // Include functions that are referenced by lddw.
+    for fi in cfg
+        .all_blocks()
+        .flat_map(|(_, block)| block.instructions())
+        .filter_map(|node| node.instruction())
+        .filter(|instruction| instruction.opcode == Opcode::Lddw)
+        .filter_map(|instruction| instruction.imm.as_ref()?.as_ref().left())
+        .filter_map(|label| {
+            cfg.functions()
+                .iter()
+                .position(|function| function.name() == label)
+        })
+    {
+        if enqueued_funcs.insert(fi) {
+            initial_blocks.extend_from_slice(cfg.functions()[fi].block_ids());
+        }
+    }
+
     let mut visitor = EnqueueFunctionBlocks {
         cfg,
-        enqueued_funcs: HashSet::from([entry_fi]),
+        enqueued_funcs,
     };
 
     let mut engine = WorklistEngine::new(cfg);
-    engine.initialize(cfg.functions()[entry_fi].block_ids().iter().copied());
+    engine.initialize(initial_blocks);
     engine.run(&mut visitor);
 
     // Every function that had at least one block visited is reachable.
@@ -145,6 +179,66 @@ mod tests {
         assert_eq!(cfg.functions().len(), 2);
         assert_eq!(cfg.functions()[0].name(), "entrypoint");
         assert_eq!(cfg.functions()[1].name(), "callee");
+    }
+
+    #[test]
+    fn test_remove_dead_functions_keeps_rodata_function_target() {
+        let entry_exit = instruction(Opcode::Exit, None);
+        let target_exit = instruction(Opcode::Exit, None);
+        let dead_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&entry_exit),
+            InputNode::Label("target"),
+            InputNode::Instruction(&target_exit),
+            InputNode::Label("dead"),
+            InputNode::Instruction(&dead_exit),
+        ];
+        let function_entries = HashSet::from([
+            "entrypoint".to_string(),
+            "target".to_string(),
+            "dead".to_string(),
+        ]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+        cfg.set_rodata([sbpf_ir::CfgRodata::new("pointer", 0, 8)], [(0, "target")]);
+        assert_eq!(cfg.rodata()[0].referenced_blocks, [1]);
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "dead");
+        assert!(cfg.functions().iter().any(|f| f.name() == "entrypoint"));
+        assert!(cfg.functions().iter().any(|f| f.name() == "target"));
+    }
+
+    #[test]
+    fn test_remove_dead_functions_keeps_lddw_function_target() {
+        let lddw = lddw_instruction("target");
+        let entry_exit = instruction(Opcode::Exit, None);
+        let target_exit = instruction(Opcode::Exit, None);
+        let dead_exit = instruction(Opcode::Exit, None);
+        let nodes = [
+            InputNode::Label("entrypoint"),
+            InputNode::Instruction(&lddw),
+            InputNode::Instruction(&entry_exit),
+            InputNode::Label("target"),
+            InputNode::Instruction(&target_exit),
+            InputNode::Label("dead"),
+            InputNode::Instruction(&dead_exit),
+        ];
+        let function_entries = HashSet::from([
+            "entrypoint".to_string(),
+            "target".to_string(),
+            "dead".to_string(),
+        ]);
+        let mut cfg = control_flow_graph(nodes, &function_entries, None);
+
+        let removed = remove_dead_functions(&mut cfg);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "dead");
+        assert!(cfg.functions().iter().any(|f| f.name() == "entrypoint"));
+        assert!(cfg.functions().iter().any(|f| f.name() == "target"));
     }
 
     #[test]
@@ -212,6 +306,17 @@ mod tests {
     fn call_instruction(target: &str) -> Instruction {
         Instruction {
             opcode: Opcode::Call,
+            dst: None,
+            src: None,
+            off: None,
+            imm: Some(Either::Left(target.to_string())),
+            span: 0..0,
+        }
+    }
+
+    fn lddw_instruction(target: &str) -> Instruction {
+        Instruction {
+            opcode: Opcode::Lddw,
             dst: None,
             src: None,
             off: None,

--- a/crates/assembler/src/ast.rs
+++ b/crates/assembler/src/ast.rs
@@ -5,7 +5,7 @@ use {
         dynsym::{DynamicSymbolMap, RelDynMap, RelocationType},
         header::ProgramHeader,
         optimizer,
-        parser::ProgramLayout,
+        parser::{ProgramLayout, Token},
         section::{CodeSection, DataSection},
     },
     either::Either,
@@ -23,6 +23,14 @@ use {
 
 type LabelOffsetMap = HashMap<String, u64>;
 type NumericLabel = (String, u64, usize);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RodataRelocation {
+    // Offset of the relocation in rodata
+    pub offset: u64,
+    // Target label whose address should be written at the relocation offset
+    pub target: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OptimizationConfig {
@@ -63,6 +71,7 @@ pub struct AST {
     function_entries: HashSet<String>,
     text_size: u64,
     rodata_size: u64,
+    rodata_relocations: Vec<RodataRelocation>,
 }
 
 impl AST {
@@ -74,8 +83,17 @@ impl AST {
         self.function_entries.insert(name);
     }
 
+    pub fn add_rodata_relocation(&mut self, offset: u64, target: String) {
+        self.rodata_relocations
+            .push(RodataRelocation { offset, target });
+    }
+
     pub(crate) fn function_entries(&self) -> &HashSet<String> {
         &self.function_entries
+    }
+
+    pub(crate) fn rodata_relocations(&self) -> &[RodataRelocation] {
+        &self.rodata_relocations
     }
 
     //
@@ -165,11 +183,12 @@ pub fn build_program(
 
     let (label_offset_map, numeric_labels) = label_offset_map(&ast);
     let program_is_static = arch.is_v3()
-        || !ast.nodes.iter().any(|node| {
-            matches!(node, ASTNode::Instruction { instruction: inst, .. }
-                if inst.is_syscall()
-                || (inst.opcode == Opcode::Lddw && matches!(&inst.imm, Some(Either::Left(_)))))
-        });
+        || (ast.rodata_relocations.is_empty()
+            && !ast.nodes.iter().any(|node| {
+                matches!(node, ASTNode::Instruction { instruction: inst, .. }
+                    if inst.is_syscall()
+                    || (inst.opcode == Opcode::Lddw && matches!(&inst.imm, Some(Either::Left(_)))))
+            }));
 
     let label_resolution = resolve_label_references(
         &mut ast,
@@ -380,6 +399,72 @@ fn resolve_label_references(
         dynamic_symbols.add_entry_point(entry_label, *offset);
     }
 
+    // Resolve rodata relocations and write their target addresses.
+    for relocation in &ast.rodata_relocations {
+        let Some(&target_offset) = label_offset_map.get(&relocation.target) else {
+            errors.push(CompileError::UndefinedLabel {
+                label: relocation.target.clone(),
+                span: 0..0,
+                custom_label: None,
+            });
+            continue;
+        };
+        let value = if arch.is_v3() {
+            if target_offset >= ast.text_size {
+                ProgramHeader::V3_RODATA_VADDR + target_offset - ast.text_size
+            } else {
+                ProgramHeader::V3_BYTECODE_VADDR + target_offset
+            }
+        } else {
+            let ph_count = if program_is_static { 1 } else { 3 };
+            (64 + ph_count * 56 + target_offset) << 32
+        };
+
+        let mut written = false;
+        for node in &mut ast.rodata_nodes {
+            let ASTNode::ROData { rodata, offset } = node else {
+                continue;
+            };
+            let Some(Token::VectorLiteral(bytes, _)) = rodata.args.get_mut(1) else {
+                continue;
+            };
+            let Some(relocation_offset_in_node) = relocation.offset.checked_sub(*offset) else {
+                continue;
+            };
+
+            // Write the target address at the relocation offset.
+            if let Some(relocation_bytes) = bytes
+                .get_mut(relocation_offset_in_node as usize..relocation_offset_in_node as usize + 8)
+            {
+                for (byte, value) in relocation_bytes.iter_mut().zip(value.to_le_bytes()) {
+                    *byte = Number::Int(i64::from(value));
+                }
+                written = true;
+                break;
+            }
+        }
+
+        if !written {
+            errors.push(CompileError::BytecodeError {
+                error: format!(
+                    "could not apply rodata relocation at offset {}",
+                    relocation.offset
+                ),
+                span: 0..0,
+                custom_label: None,
+            });
+            continue;
+        }
+
+        if !arch.is_v3() {
+            relocations.add_rel_dyn(
+                ast.text_size + relocation.offset,
+                RelocationType::RSbf64Relative,
+                String::new(),
+            );
+        }
+    }
+
     LabelResolution {
         dynamic_symbols,
         relocations,
@@ -411,7 +496,7 @@ fn label_offset_map(ast: &AST) -> (LabelOffsetMap, Vec<NumericLabel>) {
 mod tests {
     use {
         super::*,
-        crate::{astnode::Label, parser::Token},
+        crate::{astnode::Label, parser::Token, section::Section},
     };
 
     #[test]
@@ -703,6 +788,89 @@ mod tests {
         assert!(!parse_result.relocation_data.get_rel_dyns().is_empty());
     }
 
+    #[test]
+    fn test_build_program_rodata_data_relocation_v0() {
+        let result = build_program(
+            rodata_data_relocation_ast(),
+            SbpfArch::V0,
+            OptimizationConfig::default(),
+        );
+        assert!(result.is_ok());
+        let layout = result.unwrap();
+        assert!(!layout.prog_is_static);
+        let target_address: u64 = 64 + 3 * 56 + 8 + 8;
+        assert_eq!(
+            &layout.data_section.bytecode()[..8],
+            &(target_address << 32).to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn test_build_program_rodata_data_relocation_v3() {
+        let result = build_program(
+            rodata_data_relocation_ast(),
+            SbpfArch::V3,
+            OptimizationConfig::default(),
+        );
+        assert!(result.is_ok());
+        let layout = result.unwrap();
+        assert!(layout.prog_is_static);
+        assert_eq!(
+            &layout.data_section.bytecode()[..8],
+            &(ProgramHeader::V3_RODATA_VADDR + 8).to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn test_build_program_rodata_fn_relocation_v0() {
+        let result = build_program(
+            rodata_fn_relocation_ast(),
+            SbpfArch::V0,
+            OptimizationConfig::default(),
+        );
+        assert!(result.is_ok());
+        let layout = result.unwrap();
+        assert!(!layout.prog_is_static);
+        let target_address: u64 = 64 + 3 * 56;
+        assert_eq!(
+            &layout.data_section.bytecode()[..8],
+            &(target_address << 32).to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn test_build_program_rodata_fn_relocation_v3() {
+        let result = build_program(
+            rodata_fn_relocation_ast(),
+            SbpfArch::V3,
+            OptimizationConfig::default(),
+        );
+        assert!(result.is_ok());
+        let layout = result.unwrap();
+        assert!(layout.prog_is_static);
+        assert_eq!(
+            &layout.data_section.bytecode()[..8],
+            &ProgramHeader::V3_BYTECODE_VADDR.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn test_build_program_rodata_relocation_undefined_label() {
+        let mut ast = AST::new();
+        ast.nodes
+            .push(instruction_node(Opcode::Exit, 0, None, None));
+        ast.add_rodata_relocation(8, "invalid".to_string());
+        ast.set_text_size(8);
+        let result = build_program(ast, SbpfArch::V0, OptimizationConfig::default());
+        let Err(errors) = result else {
+            panic!("expected undefined label");
+        };
+        assert!(matches!(
+            &errors[..],
+            [CompileError::UndefinedLabel { label, .. }] if label == "invalid"
+        ));
+    }
+
     fn label_node(name: &str, offset: u64) -> ASTNode {
         ASTNode::Label {
             label: Label {
@@ -744,5 +912,61 @@ mod tests {
             },
             offset,
         }
+    }
+
+    // Test AST with a rodata relocation targeting data in the rodata section.
+    fn rodata_data_relocation_ast() -> AST {
+        let mut ast = AST::new();
+        ast.nodes
+            .push(instruction_node(Opcode::Exit, 0, None, None));
+        ast.rodata_nodes.push(ASTNode::ROData {
+            rodata: ROData {
+                name: "ptr".to_string(),
+                args: vec![
+                    Token::Directive("byte".to_string(), 0..1),
+                    Token::VectorLiteral(vec![Number::Int(0); 8], 0..1),
+                ],
+                span: 0..1,
+            },
+            offset: 0,
+        });
+        ast.rodata_nodes.push(ASTNode::ROData {
+            rodata: ROData {
+                name: "data".to_string(),
+                args: vec![
+                    Token::Directive("byte".to_string(), 0..1),
+                    Token::VectorLiteral(vec![Number::Int(0); 8], 0..1),
+                ],
+                span: 0..1,
+            },
+            offset: 8,
+        });
+        ast.add_rodata_relocation(0, "data".to_string());
+        ast.set_text_size(8);
+        ast.set_rodata_size(16);
+        ast
+    }
+
+    // Test AST with a rodata relocation targeting a function in the text section.
+    fn rodata_fn_relocation_ast() -> AST {
+        let mut ast = AST::new();
+        ast.nodes.push(label_node("fn", 0));
+        ast.nodes
+            .push(instruction_node(Opcode::Exit, 0, None, None));
+        ast.rodata_nodes.push(ASTNode::ROData {
+            rodata: ROData {
+                name: "ptr".to_string(),
+                args: vec![
+                    Token::Directive("byte".to_string(), 0..1),
+                    Token::VectorLiteral(vec![Number::Int(0); 8], 0..1),
+                ],
+                span: 0..1,
+            },
+            offset: 0,
+        });
+        ast.add_rodata_relocation(0, "fn".to_string());
+        ast.set_text_size(8);
+        ast.set_rodata_size(8);
+        ast
     }
 }

--- a/crates/assembler/src/optimizer/mod.rs
+++ b/crates/assembler/src/optimizer/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use canonicalize::{
 use {
     crate::{ast::AST, astnode::ASTNode},
     sbpf_analyze::remove_dead_functions,
-    sbpf_ir::{Cfg, InputNode, control_flow_graph},
+    sbpf_ir::{Cfg, CfgRodata, InputNode, control_flow_graph},
     std::collections::HashSet,
 };
 
@@ -107,7 +107,21 @@ fn cfg_for_ast(ast: &AST) -> Cfg {
         ASTNode::Instruction { instruction, .. } => InputNode::Instruction(instruction),
         _ => InputNode::Other,
     });
-    control_flow_graph(nodes, &function_entries, entry_label)
+    let mut cfg = control_flow_graph(nodes, &function_entries, entry_label);
+    if !ast.rodata_nodes.is_empty() {
+        let rodata = ast.rodata_nodes.iter().filter_map(|node| {
+            let ASTNode::ROData { rodata, offset } = node else {
+                return None;
+            };
+            Some(CfgRodata::new(&rodata.name, *offset, rodata.get_size()))
+        });
+        let references = ast
+            .rodata_relocations()
+            .iter()
+            .map(|relocation| (relocation.offset, relocation.target.as_str()));
+        cfg.set_rodata(rodata, references);
+    }
+    cfg
 }
 
 fn function_entries(ast: &AST) -> HashSet<String> {
@@ -118,9 +132,16 @@ fn function_entries(ast: &AST) -> HashSet<String> {
 mod tests {
     use {
         super::*,
-        crate::astnode::{GlobalDecl, Label},
+        crate::{
+            astnode::{GlobalDecl, Label, ROData},
+            parser::Token,
+        },
         either::Either,
-        sbpf_common::{inst_param::Register, instruction::Instruction, opcode::Opcode},
+        sbpf_common::{
+            inst_param::{Number, Register},
+            instruction::Instruction,
+            opcode::Opcode,
+        },
     };
 
     #[test]
@@ -242,6 +263,58 @@ mod tests {
             ast.nodes
                 .iter()
                 .any(|node| matches!(node, ASTNode::Label { label, .. } if label.name == "helper"))
+        );
+        assert!(
+            !ast.nodes
+                .iter()
+                .any(|node| matches!(node, ASTNode::Label { label, .. } if label.name == "dead"))
+        );
+    }
+
+    #[test]
+    fn test_optimizer_preserves_function_targeted_by_rodata_relocation() {
+        let mut ast = AST::new();
+        ast.add_function_entry("entrypoint".to_string());
+        ast.add_function_entry("target".to_string());
+        ast.add_function_entry("dead".to_string());
+        ast.nodes = vec![
+            ASTNode::GlobalDecl {
+                global_decl: GlobalDecl {
+                    entry_label: "entrypoint".to_string(),
+                    span: 0..0,
+                },
+            },
+            label_node("entrypoint", 0),
+            instruction_node(Opcode::Exit, None, 0, None),
+            label_node("target", 8),
+            instruction_node(Opcode::Exit, None, 8, None),
+            label_node("dead", 16),
+            instruction_node(Opcode::Exit, None, 16, None),
+        ];
+        ast.rodata_nodes.push(ASTNode::ROData {
+            rodata: ROData {
+                name: "pointer".to_string(),
+                args: vec![
+                    Token::Directive("quad".to_string(), 0..0),
+                    Token::VectorLiteral(vec![Number::Int(0)], 0..0),
+                ],
+                span: 0..0,
+            },
+            offset: 0,
+        });
+        ast.set_text_size(24);
+        ast.set_rodata_size(8);
+        ast.add_rodata_relocation(0, "target".to_string());
+
+        eliminate_unreachable_functions(&mut ast);
+
+        assert!(ast.nodes.iter().any(
+            |node| matches!(node, ASTNode::Label { label, .. } if label.name == "entrypoint")
+        ));
+        assert!(
+            ast.nodes
+                .iter()
+                .any(|node| matches!(node, ASTNode::Label { label, .. } if label.name == "target"))
         );
         assert!(
             !ast.nodes

--- a/crates/disassembler/src/relocation.rs
+++ b/crates/disassembler/src/relocation.rs
@@ -69,7 +69,7 @@ impl Relocation {
         let mut relocations = Vec::new();
 
         // Parse relocation entries
-        for chunk in rel_dyn_data.chunks_exact(16) {
+        for chunk in rel_dyn_data.as_chunks::<16>().0 {
             let offset = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
             let rel_type_val = u32::from_le_bytes(chunk[8..12].try_into().unwrap());
             let rel_type = match RelocationType::try_from(rel_type_val) {

--- a/crates/ir/src/cfg.rs
+++ b/crates/ir/src/cfg.rs
@@ -9,6 +9,25 @@ use {
 pub type BlockId = usize;
 pub type FunctionId = usize;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CfgRodata {
+    pub name: String,
+    pub section_offset: u64,
+    pub size: u64,
+    pub referenced_blocks: Vec<BlockId>,
+}
+
+impl CfgRodata {
+    pub fn new(name: impl Into<String>, section_offset: u64, size: u64) -> Self {
+        Self {
+            name: name.into(),
+            section_offset,
+            size,
+            referenced_blocks: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum InputNode<'a> {
     Label(&'a str),
@@ -75,6 +94,7 @@ pub struct Cfg {
     pub functions: Vec<CfgFunction>,
     pub successors: Vec<SmallVec<[BlockId; 3]>>,
     pub predecessors: Vec<SmallVec<[BlockId; 3]>>,
+    pub rodata: Vec<CfgRodata>,
 }
 
 /// Builds a CFG in source order. If `entry_label` names a known function entry,
@@ -93,6 +113,7 @@ pub fn control_flow_graph<'a>(
         functions,
         successors: vec![SmallVec::new(); n_blocks],
         predecessors: vec![SmallVec::new(); n_blocks],
+        rodata: Vec::new(),
     };
 
     for (from, to) in collect_edges(&cfg) {
@@ -105,6 +126,35 @@ pub fn control_flow_graph<'a>(
 impl Cfg {
     pub fn functions(&self) -> &[CfgFunction] {
         &self.functions
+    }
+
+    pub fn rodata(&self) -> &[CfgRodata] {
+        &self.rodata
+    }
+
+    /// Store rodata objects and resolve their references to blocks.
+    pub fn set_rodata<'a>(
+        &mut self,
+        rodata: impl IntoIterator<Item = CfgRodata>,
+        references: impl IntoIterator<Item = (u64, &'a str)>,
+    ) {
+        self.rodata = rodata.into_iter().collect();
+
+        let label_to_block = label_to_block_map(self);
+        for (offset, target) in references {
+            let Some(target) = label_to_block.get(target).copied() else {
+                continue;
+            };
+            let Some(data) = self.rodata.iter_mut().find(|data| {
+                offset >= data.section_offset
+                    && offset
+                        .checked_add(8)
+                        .is_some_and(|end| end <= data.section_offset.saturating_add(data.size))
+            }) else {
+                continue;
+            };
+            data.referenced_blocks.push(target);
+        }
     }
 
     /// Returns a block by its global BlockId.

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -3,7 +3,7 @@ pub mod dataflow;
 pub mod graph_engine;
 
 pub use {
-    cfg::{Block, BlockId, Cfg, CfgFunction, FunctionId, InputNode, control_flow_graph},
+    cfg::{Block, BlockId, Cfg, CfgFunction, CfgRodata, FunctionId, InputNode, control_flow_graph},
     dataflow::{
         InstId, InstructionNode, InstructionVisitor, walk_instruction_node, walk_instruction_nodes,
     },


### PR DESCRIPTION
### Summary

Handle rodata relocations. 

- Add a new method `AST::add_rodata_relocation` to record each rodata relocation’s offset and target label. During program construction, the target label is resolved and its address is written at the relocation offset. v0 programs also emit `R_BPF_64_RELATIVE` relocation entries. This method will mainly be used by `sbpf-linker`, which parses rodata relocations from the ELF produced by `bpf-linker` and records them in the AST so they are correctly resolved in the final sBPF output. Related sbpf-linker PR: https://github.com/blueshift-gg/sbpf-linker/pull/54
- Functions referenced only through rodata relocations have no CFG call edges, so DFE currently considers them unused and removes them. This caused runtime errors in programs that use function pointers. To fix this, store rodata information in the `cfg::CFG` struct and use it during DFE to ensure that functions referenced by rodata are not removed.