### PR TITLE
feat: add emit flag to generate asm file with watermark on it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2278,7 @@ name = "sbpf"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "codespan-reporting",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 codespan-reporting = "0.13.1"
 termcolor = "1.4"
+chrono = { version = "0.4", default-features = false, features = ["now"] }
 
 sbpf-assembler = { workspace = true }
 sbpf-common = { workspace = true }

--- a/crates/disassembler/src/relocation.rs
+++ b/crates/disassembler/src/relocation.rs
@@ -69,7 +69,7 @@ impl Relocation {
         let mut relocations = Vec::new();
 
         // Parse relocation entries
-        for chunk in rel_dyn_data.chunks_exact(16) {
+        for chunk in rel_dyn_data.as_chunks::<16>().0 {
             let offset = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
             let rel_type_val = u32::from_le_bytes(chunk[8..12].try_into().unwrap());
             let rel_type = match RelocationType::try_from(rel_type_val) {

--- a/src/commands/disassemble.rs
+++ b/src/commands/disassemble.rs
@@ -35,7 +35,7 @@ pub struct DisassembleArgs {
     )]
     pub raw: bool,
 
-    #[arg(short, long, help = "Emit asm file from the disassembled input")]
+    #[arg(short, long, help = "Emit the input program's disassembly to a file")]
     pub emit: bool,
 }
 
@@ -91,14 +91,23 @@ pub fn disassemble(args: DisassembleArgs) -> Result<(), Error> {
             .file_stem()
             .and_then(|name| name.to_str())
             .expect("we should have a file");
-        let content = render_asm(
+
+        let asm = render_asm(
             disassembled.value,
             entrypoint_offset,
             &text,
             format,
             args.raw,
-            true,
         )?;
+
+        let mut content = String::new();
+        content.push_str(&format!(
+            "# Generated with sbpf v{}\n# Generated on: {date}\n\n",
+            env!("CARGO_PKG_VERSION"),
+            date = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+        ));
+        content.push_str(asm.as_str());
+
         fs::write(format!("{file_name}.s"), content)?;
     } else {
         print!(
@@ -109,7 +118,6 @@ pub fn disassemble(args: DisassembleArgs) -> Result<(), Error> {
                 &text,
                 format,
                 args.raw,
-                false
             )?
         );
     }
@@ -123,16 +131,8 @@ fn render_asm(
     text: &[u8],
     format: AsmFormat,
     raw: bool,
-    watermark: bool,
 ) -> Result<String, Error> {
     let mut output = String::new();
-
-    if watermark {
-        output.push_str(&format!(
-            "# Generated with sbpf v{}\n",
-            env!("CARGO_PKG_VERSION")
-        ));
-    }
 
     let print_error = |output: &mut String, indent: &str, e: &DisassemblerError| {
         if let DisassemblerError::BytecodeError { error, span } = e
@@ -297,15 +297,7 @@ mod tests {
             program.to_ixs()
         }
         .unwrap();
-        render_asm(
-            disassembled.value,
-            entrypoint_offset,
-            &text,
-            format,
-            raw,
-            false,
-        )
-        .unwrap()
+        render_asm(disassembled.value, entrypoint_offset, &text, format, raw).unwrap()
     }
 
     #[test]

--- a/src/commands/disassemble.rs
+++ b/src/commands/disassemble.rs
@@ -7,13 +7,18 @@ use {
         errors::DisassemblerError,
         program::{Disassembly, Program},
     },
-    std::{collections::HashSet, fs::File, io::Read},
+    std::{
+        collections::HashSet,
+        fs::{self, File},
+        io::Read,
+        path::PathBuf,
+    },
 };
 
 #[derive(Args)]
 pub struct DisassembleArgs {
     #[arg(help = "Path to the ELF file (.so) to disassemble")]
-    pub filename: String,
+    pub filepath: PathBuf,
     #[arg(short, long, help = "Output full JSON debug information")]
     pub debug: bool,
     #[arg(
@@ -29,10 +34,13 @@ pub struct DisassembleArgs {
         help = "Output raw instructions without labels or formatting"
     )]
     pub raw: bool,
+
+    #[arg(short, long, help = "Emit asm file from the disassembled input")]
+    pub emit: bool,
 }
 
 pub fn disassemble(args: DisassembleArgs) -> Result<(), Error> {
-    let mut file = File::open(&args.filename)?;
+    let mut file = File::open(&args.filepath)?;
     let mut b = vec![];
     file.read_to_end(&mut b)?;
 
@@ -77,16 +85,35 @@ pub fn disassemble(args: DisassembleArgs) -> Result<(), Error> {
 
     report(&disassembled.errors);
 
-    print!(
-        "{}",
-        render_asm(
+    if args.emit {
+        let file_name = args
+            .filepath
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .expect("we should have a file");
+        let content = render_asm(
             disassembled.value,
             entrypoint_offset,
             &text,
             format,
-            args.raw
-        )?
-    );
+            args.raw,
+            true,
+        )?;
+        fs::write(format!("{file_name}.s"), content)?;
+    } else {
+        print!(
+            "{}",
+            render_asm(
+                disassembled.value,
+                entrypoint_offset,
+                &text,
+                format,
+                args.raw,
+                false
+            )?
+        );
+    }
+
     Ok(())
 }
 
@@ -96,8 +123,16 @@ fn render_asm(
     text: &[u8],
     format: AsmFormat,
     raw: bool,
+    watermark: bool,
 ) -> Result<String, Error> {
     let mut output = String::new();
+
+    if watermark {
+        output.push_str(&format!(
+            "# Generated with sbpf v{}\n",
+            env!("CARGO_PKG_VERSION")
+        ));
+    }
 
     let print_error = |output: &mut String, indent: &str, e: &DisassemblerError| {
         if let DisassemblerError::BytecodeError { error, span } = e
@@ -262,7 +297,15 @@ mod tests {
             program.to_ixs()
         }
         .unwrap();
-        render_asm(disassembled.value, entrypoint_offset, &text, format, raw).unwrap()
+        render_asm(
+            disassembled.value,
+            entrypoint_offset,
+            &text,
+            format,
+            raw,
+            false,
+        )
+        .unwrap()
     }
 
     #[test]


### PR DESCRIPTION
## Description

Introduce new `--emit` flag to the `disassemble` command that generates a `.s` file with the content from the disassembled input with a watermark containing the version of the cli. 

## Changes

- Add emit flag to the `Disassemble` command struct

- Change `filepath` to be a `PathBuf` instead of a `String` to access it's path-specific commands and express the correct domain type

- Add watermark variable to the `render_asm` function to add the watermark with the current sbpf version in the generated file